### PR TITLE
fix: parse bare odd-even week suffixes

### DIFF
--- a/src-tauri/src/schedule.rs
+++ b/src-tauri/src/schedule.rs
@@ -23,7 +23,7 @@ pub fn expand_week_numbers(week_text: &str) -> Vec<i64> {
     let mut raw = week_text.replace('，', ",").replace(' ', "");
     let odd_only = raw.contains('单');
     let even_only = raw.contains('双');
-    raw = raw.replace('周', "");
+    raw = raw.replace(['周', '单', '双'], "");
     raw = Regex::new(r"\[.*?\]")
         .expect("valid regex")
         .replace_all(&raw, "")
@@ -452,6 +452,21 @@ mod tests {
         assert_eq!(expand_week_numbers("1-5[周]"), vec![1, 2, 3, 4, 5]);
         assert_eq!(expand_week_numbers("1-5[周](单)"), vec![1, 3, 5]);
         assert_eq!(expand_week_numbers("2,4,6[周]"), vec![2, 4, 6]);
+    }
+
+    #[test]
+    fn parse_sjd_week_numbers_falls_back_to_bare_odd_even_suffixes() {
+        let odd_course = serde_json::json!({ "classWeek": "1-17单" });
+        let even_course = serde_json::json!({ "classWeek": "2-18双" });
+
+        assert_eq!(
+            parse_sjd_week_numbers(&odd_course),
+            (1..=17).step_by(2).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            parse_sjd_week_numbers(&even_course),
+            (2..=18).step_by(2).collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Strip bare `单` and `双` suffixes after recording the odd/even filter, so fallback range parsing receives numeric endpoints.
- Add regression coverage for `1-17单` and `2-18双` when `classWeekDetails` is absent.

Closes #23

## Scope

Rust/Tauri schedule parsing only. The web UI, native Android implementation, native Apple implementation, network requests, and persisted data formats are unchanged.

## Verification

- `cargo +stable-x86_64-pc-windows-gnu fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo +stable-x86_64-pc-windows-gnu clippy --manifest-path src-tauri/Cargo.toml --locked --lib -- -D warnings`
- `node --test test/planner-domain.test.js` (16 passed)
- The targeted Rust test compiled successfully with the local GNU toolchain. Executing the Tauri test binary locally was blocked by a machine-specific `STATUS_ENTRYPOINT_NOT_FOUND` WebView2/runtime loader error; the draft PR's Windows MSVC CI should provide the authoritative test execution.

## Security and privacy

No changes to credentials, authentication, transport, storage, IPC, permissions, signing, dependencies, or personal data.

## Legal status

No third-party code, assets, data, or dependencies were added. This contribution is submitted under the repository's `GPL-3.0-only` license.

## Checklist

- [x] The change is narrowly scoped and does not overwrite unrelated work.
- [x] Formatting and strict Clippy checks pass for the affected Rust code.
- [x] Logs, fixtures, and commits contain no credentials, tokens, cookies, personal data, signing keys, or private local paths.
- [x] No new dependencies or third-party materials were introduced.
- [x] User-facing behavior is corrected without requiring release-note or UI changes.
- [x] I have the right to contribute this change under `GPL-3.0-only`.