### PR TITLE
fix: normalize minimum seat settings

### DIFF
--- a/src/planner-domain.js
+++ b/src/planner-domain.js
@@ -246,6 +246,13 @@ export function courseTimeBounds(course, slotMeta) {
   }
 }
 
+function normalizeMinSeats(value) {
+  const seats = Number(value)
+  if (!Number.isFinite(seats)) return 0
+  const integerSeats = Math.trunc(seats)
+  return Number.isSafeInteger(integerSeats) ? Math.max(0, integerSeats) : 0
+}
+
 export function savedSettingsToState(data = {}, fallback = DEFAULT_SETTINGS) {
   return {
     account: data.account ?? fallback.account ?? '',
@@ -254,7 +261,7 @@ export function savedSettingsToState(data = {}, fallback = DEFAULT_SETTINGS) {
     termId: data.term_id || fallback.termId || DEFAULT_SETTINGS.termId,
     termStartDate: data.term_start_date || fallback.termStartDate || DEFAULT_SETTINGS.termStartDate,
     campusId: data.campus_id || fallback.campusId || DEFAULT_SETTINGS.campusId,
-    defaultMinSeats: Number(data.default_min_seats ?? fallback.defaultMinSeats ?? 0) || 0,
+    defaultMinSeats: normalizeMinSeats(data.default_min_seats ?? fallback.defaultMinSeats ?? 0),
     dailyCourseNotificationsEnabled: Boolean(
       data.daily_course_notifications_enabled
       ?? fallback.dailyCourseNotificationsEnabled
@@ -282,7 +289,7 @@ export function settingsToPayload(settings) {
     term_id: settings.termId,
     term_start_date: settings.termStartDate,
     campus_id: settings.campusId,
-    default_min_seats: Number(settings.defaultMinSeats) || 0,
+    default_min_seats: normalizeMinSeats(settings.defaultMinSeats),
     daily_course_notifications_enabled: Boolean(settings.dailyCourseNotificationsEnabled),
   }
 }

--- a/test/planner-domain.test.js
+++ b/test/planner-domain.test.js
@@ -141,6 +141,28 @@ test('saved settings never hydrate a password into web state', () => {
   assert.equal(accountHasSavedPassword(' student ', { account: 'student', hasSavedPassword: true }), true)
 })
 
+test('minimum seat settings remain finite non-negative integers', () => {
+  for (const value of [
+    -1,
+    Number.NEGATIVE_INFINITY,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_VALUE,
+    'invalid',
+  ]) {
+    assert.equal(savedSettingsToState({ default_min_seats: value }).defaultMinSeats, 0)
+    assert.equal(
+      settingsToPayload({ ...DEFAULT_SETTINGS, defaultMinSeats: value }).default_min_seats,
+      0,
+    )
+  }
+
+  assert.equal(savedSettingsToState({ default_min_seats: 12.9 }).defaultMinSeats, 12)
+  assert.equal(
+    settingsToPayload({ ...DEFAULT_SETTINGS, defaultMinSeats: 24.8 }).default_min_seats,
+    24,
+  )
+})
+
 test('a classroom query can override campus without changing the saved default', () => {
   const settings = { ...DEFAULT_SETTINGS, campusId: '01' }
   const queryPayload = requestBody(settings, { campus_id: '04', target_date: '2026-06-01' })


### PR DESCRIPTION
## Summary

- Normalize loaded and outgoing minimum-seat values to safe, non-negative integers.
- Convert fractional values with `Math.trunc` and fall back to zero for negative, non-finite, unsafe, or non-numeric values.
- Add regression coverage for invalid persisted values and outgoing settings payloads.

Closes #25

## Scope

Web planner domain conversion and its unit tests only. No UI layout, Rust backend, native client, persistence format, or dependency changes.

## Verification

- `node --test test/planner-domain.test.js` (17 passed)
- `npm run build`
- `git diff --check`
- Re-ran the issue reproduction: `-1/-1/1.5` now normalizes to `0/0/1`.

## Security and privacy

No changes to credentials, authentication, transport, local storage, IPC permissions, signing, dependencies, or personal data. This change only constrains a non-sensitive numeric settings field before IPC.

## Legal status

No third-party code, assets, data, or dependencies were added. This contribution is submitted under the repository's `GPL-3.0-only` license.

## Checklist

- [x] The change is narrowly scoped and does not overwrite unrelated work.
- [x] Tests and the production web build pass.
- [x] Logs, fixtures, and commits contain no credentials, tokens, cookies, personal data, signing keys, or private local paths.
- [x] No new dependencies or third-party materials were introduced.
- [x] The fix enforces the existing settings contract without changing the UI.
- [x] I have the right to contribute this change under `GPL-3.0-only`.