### PR TITLE
feat(harmony): align widgets and adaptive calendar layouts

### DIFF
--- a/native/harmony/entry/src/main/ets/common/AppTheme.ets
+++ b/native/harmony/entry/src/main/ets/common/AppTheme.ets
@@ -48,6 +48,21 @@ export class AppTheme {
     return $r('app.color.app_danger');
   }
 
+  // 当前时间/今日标记（对应 Android Palette.nowIndicator 与 Tauri --current-time）。
+  static nowIndicator(): Resource {
+    return $r('app.color.app_now_indicator');
+  }
+
+  // 法定节假日文字（对应 Android Palette.holiday）。
+  static holiday(): Resource {
+    return $r('app.color.app_holiday');
+  }
+
+  // 主色深档（对应 Android Palette.primaryDark，两模式同值）。
+  static primaryDark(): Resource {
+    return $r('app.color.app_primary_dark');
+  }
+
   // 列表选中背景（深浅色各有独立 alpha，BUG-045 修复）。
   static selection(): Resource {
     return $r('app.color.app_selection');

--- a/native/harmony/entry/src/main/ets/common/DeviceState.ets
+++ b/native/harmony/entry/src/main/ets/common/DeviceState.ets
@@ -5,6 +5,7 @@
 // - 半折叠（FOLD_STATUS_HALF_FOLDED）时屏幕被铰链分成两半，
 //   强制使用单列紧凑布局（侧栏/双列/宽日历全部退化为紧凑形态），
 //   避免铰链遮挡内容；完全展开/双屏展开按宽度使用宽布局。
+import { deviceInfo } from '@kit.BasicServicesKit';
 import { display } from '@kit.ArkUI';
 import { hilog } from '@kit.PerformanceAnalysisKit';
 
@@ -93,6 +94,16 @@ export class DeviceState {
   // 半折叠时铰链横贯屏幕中部，强制紧凑布局。
   allowsExpandedLayout(): boolean {
     return !this.isHalfFolded();
+  }
+
+  // 2in1/PC 设备类型判定：电脑端日历按 Windows Tauri 布局，
+  // 平板/手机按 Android 折叠屏布局（用户指定的平台映射）。
+  static isPc2in1(): boolean {
+    try {
+      return deviceInfo.deviceType === '2in1';
+    } catch (e) {
+      return false;
+    }
   }
 }
 

--- a/native/harmony/entry/src/main/ets/model/AppModel.ets
+++ b/native/harmony/entry/src/main/ets/model/AppModel.ets
@@ -158,6 +158,9 @@ export class AppModel {
   @Trace hasSavedPassword: boolean = false;
   @Trace termID: string = ScheduleDefaults.termID;
   @Trace termStartDate: string = ScheduleDefaults.termStartDate;
+  // 自动检测当前学期（对应 Android automaticTermDetectionEnabled）：
+  // 开启时获取/刷新课表后用教务返回的学期覆盖本地，关闭时保留手动填写值。
+  @Trace automaticTermDetection: boolean = true;
   @Trace campusID: string = '01';
   @Trace queryCampusID: string = '01';
   @Trace selectedSlots: Set<number> = new Set<number>();
@@ -261,6 +264,7 @@ export class AppModel {
     const savedCampusID: string | null = await this.preferences.getString('campusID');
     const notificationsEnabled: boolean = await this.preferences.getBool(
       DailyCourseNotificationSettings.enabledKey, false);
+    this.automaticTermDetection = await this.preferences.getBool('automaticTermDetection', true);
     this.termID = savedTermID !== null && savedTermID.length > 0 ? savedTermID : ScheduleDefaults.termID;
     this.termStartDate = savedTermStart !== null && savedTermStart.length > 0 ?
       savedTermStart : ScheduleDefaults.termStartDate;
@@ -539,6 +543,7 @@ export class AppModel {
       const savedCampusID: string | null = await this.preferences.getString('campusID');
       const notificationsEnabled: boolean = await this.preferences.getBool(
         DailyCourseNotificationSettings.enabledKey, false);
+      this.automaticTermDetection = await this.preferences.getBool('automaticTermDetection', true);
       this.termID = savedTermID !== null && savedTermID.length > 0 ? savedTermID : ScheduleDefaults.termID;
       this.termStartDate = savedTermStart !== null && savedTermStart.length > 0 ?
         savedTermStart : ScheduleDefaults.termStartDate;
@@ -621,10 +626,42 @@ export class AppModel {
       await this.preferences.setString('campusID', this.campusID);
       await this.preferences.setString('termID', this.termID);
       await this.preferences.setString('termStartDate', this.termStartDate);
+      await this.preferences.setBool('automaticTermDetection', this.automaticTermDetection);
       this.statusMessage = '设置已保存';
       return true;
     } catch (e) {
       this.statusMessage = e instanceof Error ? e.message : '设置保存失败。';
+      return false;
+    }
+  }
+
+  // 仅保存学期设置（学期编号/第一周周一/自动检测开关），不涉及账号密码
+  // （对应 Android SettingsPage.semesterSurface 的"保存学期设置"按钮）。
+  async saveSemesterSettings(): Promise<boolean> {
+    if (this.isSampleMode()) {
+      this.statusMessage = '示例模式不会保存账户或设置';
+      return false;
+    }
+    const normalizedTermID: string = this.termID.trim();
+    const normalizedTermStartDate: string = this.termStartDate.trim();
+    const nextTermID: string = normalizedTermID.length === 0 ?
+      ScheduleDefaults.termID : normalizedTermID;
+    const nextTermStartDate: string = normalizedTermStartDate.length === 0 ?
+      ScheduleDefaults.termStartDate : normalizedTermStartDate;
+    if (StrictDates.parseDateString(nextTermStartDate) === null) {
+      this.statusMessage = CredentialSettingsError.invalidTermStartDate().message;
+      return false;
+    }
+    this.termID = nextTermID;
+    this.termStartDate = nextTermStartDate;
+    try {
+      await this.preferences.setString('termID', this.termID);
+      await this.preferences.setString('termStartDate', this.termStartDate);
+      await this.preferences.setBool('automaticTermDetection', this.automaticTermDetection);
+      this.statusMessage = '学期设置已保存';
+      return true;
+    } catch (e) {
+      this.statusMessage = e instanceof Error ? e.message : '学期设置保存失败。';
       return false;
     }
   }
@@ -787,6 +824,8 @@ export class AppModel {
     await this.preferences.remove('campusID');
     await this.preferences.remove('termID');
     await this.preferences.remove('termStartDate');
+    await this.preferences.remove('automaticTermDetection');
+    this.automaticTermDetection = true;
     this.campusID = '01';
     this.queryCampusID = '01';
     this.termID = ScheduleDefaults.termID;
@@ -843,10 +882,14 @@ export class AppModel {
         this.schedule = fetched;
         this.synchronizeWidgetSchedule();
         this.calendarImportStatusMessage = '';
-        this.termID = fetched.termID;
-        this.termStartDate = fetched.termStartDate;
-        await this.preferences.setString('termID', this.termID);
-        await this.preferences.setString('termStartDate', this.termStartDate);
+        if (this.automaticTermDetection) {
+          // 自动检测开启时用教务返回的学期覆盖本地（对应 Android
+          // automaticTermDetectionEnabled）；关闭时保留手动填写值。
+          this.termID = fetched.termID;
+          this.termStartDate = fetched.termStartDate;
+          await this.preferences.setString('termID', this.termID);
+          await this.preferences.setString('termStartDate', this.termStartDate);
+        }
         this.synchronizeSelectedSlots();
         this.dailyCourseNotificationDirty = true;
         this.reconcileDailyCourseNotifications(false);

--- a/native/harmony/entry/src/main/ets/model/AppModel.ets
+++ b/native/harmony/entry/src/main/ets/model/AppModel.ets
@@ -25,6 +25,7 @@ import {
 import { AppRuntimeMode } from './AppRuntimeMode';
 import { SampleData } from './SampleData';
 import { WidgetSync } from '../widget/WidgetSync';
+import { WidgetCoursePreferences } from '../widget/TodayCourseWidgetData';
 
 export class CredentialSettingsError extends Error {
   constructor(message: string) {
@@ -161,6 +162,10 @@ export class AppModel {
   // 自动检测当前学期（对应 Android automaticTermDetectionEnabled）：
   // 开启时获取/刷新课表后用教务返回的学期覆盖本地，关闭时保留手动填写值。
   @Trace automaticTermDetection: boolean = true;
+  // 桌面小组件显示偏好（对应 Android widgetShowsLocation/widgetShowsTeacher/widgetCourseLimit）。
+  @Trace widgetShowsLocation: boolean = true;
+  @Trace widgetShowsTeacher: boolean = true;
+  @Trace widgetCourseLimit: number = WidgetCoursePreferences.defaultLimit;
   @Trace campusID: string = '01';
   @Trace queryCampusID: string = '01';
   @Trace selectedSlots: Set<number> = new Set<number>();
@@ -265,6 +270,11 @@ export class AppModel {
     const notificationsEnabled: boolean = await this.preferences.getBool(
       DailyCourseNotificationSettings.enabledKey, false);
     this.automaticTermDetection = await this.preferences.getBool('automaticTermDetection', true);
+    this.widgetShowsLocation = await this.preferences.getBool('widgetShowsLocation', true);
+    this.widgetShowsTeacher = await this.preferences.getBool('widgetShowsTeacher', true);
+    this.widgetCourseLimit = Math.min(Math.max(
+      await this.preferences.getNumber('widgetCourseLimit', WidgetCoursePreferences.defaultLimit),
+      1), WidgetCoursePreferences.maximumLimit);
     this.termID = savedTermID !== null && savedTermID.length > 0 ? savedTermID : ScheduleDefaults.termID;
     this.termStartDate = savedTermStart !== null && savedTermStart.length > 0 ?
       savedTermStart : ScheduleDefaults.termStartDate;
@@ -544,6 +554,11 @@ export class AppModel {
       const notificationsEnabled: boolean = await this.preferences.getBool(
         DailyCourseNotificationSettings.enabledKey, false);
       this.automaticTermDetection = await this.preferences.getBool('automaticTermDetection', true);
+      this.widgetShowsLocation = await this.preferences.getBool('widgetShowsLocation', true);
+      this.widgetShowsTeacher = await this.preferences.getBool('widgetShowsTeacher', true);
+      this.widgetCourseLimit = Math.min(Math.max(
+        await this.preferences.getNumber('widgetCourseLimit', WidgetCoursePreferences.defaultLimit),
+        1), WidgetCoursePreferences.maximumLimit);
       this.termID = savedTermID !== null && savedTermID.length > 0 ? savedTermID : ScheduleDefaults.termID;
       this.termStartDate = savedTermStart !== null && savedTermStart.length > 0 ?
         savedTermStart : ScheduleDefaults.termStartDate;
@@ -664,6 +679,27 @@ export class AppModel {
       this.statusMessage = e instanceof Error ? e.message : '学期设置保存失败。';
       return false;
     }
+  }
+
+  // 桌面小组件偏好：设置页即时生效并刷新全部卡片（对应 Android
+  // widgetSurface 的 Switch/Spinner 直接写偏好）。
+  async setWidgetShowsLocation(value: boolean): Promise<void> {
+    this.widgetShowsLocation = value;
+    await this.preferences.setBool('widgetShowsLocation', value);
+    this.synchronizeWidgetSchedule();
+  }
+
+  async setWidgetShowsTeacher(value: boolean): Promise<void> {
+    this.widgetShowsTeacher = value;
+    await this.preferences.setBool('widgetShowsTeacher', value);
+    this.synchronizeWidgetSchedule();
+  }
+
+  async setWidgetCourseLimit(value: number): Promise<void> {
+    const clamped: number = Math.min(Math.max(value, 1), WidgetCoursePreferences.maximumLimit);
+    this.widgetCourseLimit = clamped;
+    await this.preferences.setNumber('widgetCourseLimit', clamped);
+    this.synchronizeWidgetSchedule();
   }
 
   // ---------- 每日课程摘要 ----------
@@ -826,6 +862,12 @@ export class AppModel {
     await this.preferences.remove('termStartDate');
     await this.preferences.remove('automaticTermDetection');
     this.automaticTermDetection = true;
+    await this.preferences.remove('widgetShowsLocation');
+    await this.preferences.remove('widgetShowsTeacher');
+    await this.preferences.remove('widgetCourseLimit');
+    this.widgetShowsLocation = true;
+    this.widgetShowsTeacher = true;
+    this.widgetCourseLimit = WidgetCoursePreferences.defaultLimit;
     this.campusID = '01';
     this.queryCampusID = '01';
     this.termID = ScheduleDefaults.termID;
@@ -1266,7 +1308,8 @@ export class AppModel {
 
   // 对应 iOS 端 synchronizeWidgetSchedule：课表变化后同步“今日课程”卡片。
   private synchronizeWidgetSchedule(): void {
-    WidgetSync.refresh(this.schedule);
+    WidgetSync.refresh(this.schedule, new WidgetCoursePreferences(
+    this.widgetShowsLocation, this.widgetShowsTeacher, this.widgetCourseLimit));
   }
 
   private static todayString(): string {

--- a/native/harmony/entry/src/main/ets/store/CredentialStore.ets
+++ b/native/harmony/entry/src/main/ets/store/CredentialStore.ets
@@ -86,22 +86,29 @@ export class AssetCredentialStore implements CredentialStoring {
     const updateAttr: asset.AssetMap = credentialUpdateAttributes(credentials);
     try {
       await asset.update(AssetCredentialStore.aliasAttr(), updateAttr);
-      return;
     } catch (e) {
       const err: BusinessError = e as BusinessError;
       if (err.code !== ASSET_NOT_FOUND) {
         throw new Error('系统安全存储操作失败（' + err.code.toString() + '）。');
       }
+      const addAttr: asset.AssetMap = AssetCredentialStore.aliasAttr();
+      const encoder: util.TextEncoder = new util.TextEncoder();
+      addAttr.set(asset.Tag.SECRET, encoder.encodeInto(credentials.toJsonText()));
+      addAttr.set(asset.Tag.ACCESSIBILITY, asset.Accessibility.DEVICE_FIRST_UNLOCKED);
+      try {
+        await asset.add(addAttr);
+      } catch (e2) {
+        const err2: BusinessError = e2 as BusinessError;
+        throw new Error('系统安全存储操作失败（' + err2.code.toString() + '）。');
+      }
     }
-    const addAttr: asset.AssetMap = AssetCredentialStore.aliasAttr();
-    const encoder: util.TextEncoder = new util.TextEncoder();
-    addAttr.set(asset.Tag.SECRET, encoder.encodeInto(credentials.toJsonText()));
-    addAttr.set(asset.Tag.ACCESSIBILITY, asset.Accessibility.DEVICE_FIRST_UNLOCKED);
-    try {
-      await asset.add(addAttr);
-    } catch (e) {
-      const err: BusinessError = e as BusinessError;
-      throw new Error('系统安全存储操作失败（' + err.code.toString() + '）。');
+    // 往返校验：部分模拟器/系统镜像缺少 ASSET 扩展库（libasset_ext_ffi.z.so），
+    // update/add 不报错但实际未持久化。若不校验，后续保存会误判为"未保存过
+    // 账号"并提示"更换教务账号时必须输入新密码"。这里读回验证，未落盘即报错。
+    const stored: Credentials | null = await this.load();
+    if (stored === null || stored.account !== credentials.account ||
+      stored.password !== credentials.password) {
+      throw new Error('系统安全存储不可用，账号密码未能保存，请稍后重试。');
     }
   }
 

--- a/native/harmony/entry/src/main/ets/store/PreferencesStore.ets
+++ b/native/harmony/entry/src/main/ets/store/PreferencesStore.ets
@@ -29,6 +29,12 @@ export class PreferencesStore {
     return typeof value === 'boolean' ? value as boolean : fallback;
   }
 
+  async getNumber(key: string, fallback: number): Promise<number> {
+    const store: preferences.Preferences = await this.open();
+    const value: preferences.ValueType = await store.get(key, fallback);
+    return typeof value === 'number' ? value as number : fallback;
+  }
+
   async getStringArray(key: string): Promise<string[]> {
     const store: preferences.Preferences = await this.open();
     const value: preferences.ValueType = await store.get(key, []);
@@ -66,6 +72,12 @@ export class PreferencesStore {
   }
 
   async setBool(key: string, value: boolean): Promise<void> {
+    const store: preferences.Preferences = await this.open();
+    await store.put(key, value);
+    await store.flush();
+  }
+
+  async setNumber(key: string, value: number): Promise<void> {
     const store: preferences.Preferences = await this.open();
     await store.put(key, value);
     await store.flush();

--- a/native/harmony/entry/src/main/ets/view/PlannerView.ets
+++ b/native/harmony/entry/src/main/ets/view/PlannerView.ets
@@ -17,6 +17,8 @@ export class PlannerLayoutMetrics {
 export struct PlannerView {
   @Consumer('appModel') model: AppModel = new AppModel();
   @Local contentWidth: number = 350;
+  // 宽屏双列时左列（查询/节次/教学楼）实际宽度，用于节次/教学楼列数计算。
+  @Local leftColumnWidth: number = 300;
   // 当天日期文本：跨午夜自动刷新（BUG-024 修复）。
   @Local todayText: string = StrictDates.formatDateParts(StrictDates.todayParts());
   // 派生数据缓存（BUG-015/023 修复）：由 @Monitor 在依赖状态变化时刷新。
@@ -59,7 +61,7 @@ export struct PlannerView {
   }
 
   private slotColumnCount(): number {
-    const available: number = Math.max(this.contentWidth, 200);
+    const available: number = Math.max(this.sectionWidth(), 200);
     const count: number = Math.floor(
       (available + PlannerLayoutMetrics.slotSpacing) /
       (PlannerLayoutMetrics.slotMinimumWidth + PlannerLayoutMetrics.slotSpacing));
@@ -67,7 +69,7 @@ export struct PlannerView {
   }
 
   private buildingColumnCount(): number {
-    const available: number = Math.max(this.contentWidth, 200);
+    const available: number = Math.max(this.sectionWidth(), 200);
     const count: number = Math.floor(
       (available + PlannerLayoutMetrics.buildingSpacing) /
       (PlannerLayoutMetrics.buildingMinimumWidth + PlannerLayoutMetrics.buildingSpacing));
@@ -76,6 +78,17 @@ export struct PlannerView {
 
   private isCompact(): boolean {
     return this.contentWidth < 700;
+  }
+
+  // 宽屏（>= 760vp，对应 AdaptiveLayoutPolicy.useTwoColumn）双列布局，
+  // 与 iOS PlannerView 的 HStack 双列一致：左列 1/3、右列 2/3。
+  private twoColumn(): boolean {
+    return this.contentWidth >= 760;
+  }
+
+  // 节次/教学楼网格按所在列的实际宽度计算（双列时用左列宽度）。
+  private sectionWidth(): number {
+    return this.twoColumn() ? this.leftColumnWidth : this.contentWidth;
   }
 
   private sectionSpacing(): number {
@@ -94,14 +107,46 @@ export struct PlannerView {
     Scroll() {
       Column({ space: this.sectionSpacing() }) {
         this.header()
-        this.querySurface()
-        this.slotSurface()
-        this.todayCoursesSurface()
-        this.buildingsSurface()
-        this.resultsSurface()
-        this.summarySurface()
-        if (this.isCompact()) {
-          Blank().height(72)
+        if (this.twoColumn()) {
+          // 宽屏双列：左列 = 查询条件/节次筛选/教学楼（1/3），
+          // 右列 = 当天课程/空教室结果/查询概览（2/3），对应 iOS HStack。
+          Row({ space: 16 }) {
+            Column({ space: 16 }) {
+              this.querySurface()
+              this.slotSurface()
+              this.buildingsSurface()
+            }
+            .layoutWeight(1)
+            .width('100%')
+            .alignItems(HorizontalAlign.Start)
+            .onAreaChange((oldArea: Area, newArea: Area) => {
+              this.leftColumnWidth = Number(newArea.width);
+            })
+            Column({ space: 16 }) {
+              this.todayCoursesSurface()
+              this.resultsSurface()
+              this.summarySurface()
+            }
+            .layoutWeight(2)
+            .width('100%')
+            .alignItems(HorizontalAlign.Start)
+          }
+          .width('100%')
+          .alignItems(VerticalAlign.Top)
+        } else {
+          Column({ space: this.sectionSpacing() }) {
+            this.querySurface()
+            this.slotSurface()
+            this.todayCoursesSurface()
+            this.buildingsSurface()
+            this.resultsSurface()
+            this.summarySurface()
+          }
+          .width('100%')
+          .alignItems(HorizontalAlign.Start)
+          if (this.isCompact()) {
+            Blank().height(72)
+          }
         }
       }
       .padding({ left: 20, right: 20, top: 20, bottom: 28 })

--- a/native/harmony/entry/src/main/ets/view/SettingsView.ets
+++ b/native/harmony/entry/src/main/ets/view/SettingsView.ets
@@ -65,8 +65,9 @@ export struct SettingsView {
         this.settingsTitle()
         if (AdaptiveLayoutPolicy.useTwoColumn(this.contentWidth)) {
           Row({ space: 16 }) {
-            Column() {
+            Column({ space: 16 }) {
               this.accountSurface()
+              this.semesterSurface()
             }
             .layoutWeight(1)
             .alignItems(HorizontalAlign.Start)
@@ -84,6 +85,7 @@ export struct SettingsView {
         } else {
           Column({ space: 16 }) {
             this.accountSurface()
+            this.semesterSurface()
             this.notificationSurface()
             this.localDataSurface()
             this.aboutSurface()
@@ -159,58 +161,6 @@ export struct SettingsView {
           .width('100%')
           .padding({ left: 2, right: 2, top: 7 })
       }
-      Blank().height(7)
-      this.field('学期编号', this.model.termID, InputType.Normal, (value: string): void => {
-        this.model.termID = value;
-      })
-      Blank().height(7)
-      this.field('第一周周一（YYYY-MM-DD）', this.model.termStartDate, InputType.Normal,
-        (value: string): void => {
-          this.model.termStartDate = value;
-        })
-
-      Blank().height(7)
-      Button('按当前日期自动检测')
-        .type(ButtonType.Normal)
-        .stateEffect(true)
-        .fontSize(15)
-        .fontWeight(FontWeight.Bold)
-        .fontColor(AppTheme.primary())
-        .borderRadius(6)
-        .border({ width: 1, color: AppTheme.primary() })
-        .backgroundColor(AppTheme.surface())
-        .width('100%')
-        .height(36)
-        .enabled(!this.model.isSampleMode())
-        .clickEffect({ level: ClickEffectLevel.MIDDLE, scale: 0.98 })
-        .onClick(() => {
-          const suggested: SemesterSuggestion = SemesterLogic.suggestCurrentPeriod();
-          this.model.termID = suggested.termID;
-          this.model.termStartDate = suggested.termStartDate;
-        })
-      if (SemesterLogic.matchesCurrentPeriod(this.model.termID, this.model.termStartDate)) {
-        Text('✓ 与当前学期一致')
-          .fontSize(13)
-          .fontWeight(FontWeight.Medium)
-          .fontColor(AppTheme.primary())
-          .width('100%')
-          .padding({ left: 2, right: 2, top: 7 })
-      } else if (SemesterLogic.isValidTermID(this.model.termID) &&
-        SemesterLogic.isValidTermStartDate(this.model.termStartDate)) {
-        Text('当前设置与检测结果不同')
-          .fontSize(13)
-          .fontWeight(FontWeight.Medium)
-          .fontColor(AppTheme.accent())
-          .width('100%')
-          .padding({ left: 2, right: 2, top: 7 })
-      }
-      Text('获取/刷新课表后会自动应用教务返回的学期与开学日期，无需手动填写。')
-        .fontSize(12)
-        .fontColor(AppTheme.secondaryText())
-        .lineHeight(17)
-        .width('100%')
-        .padding({ left: 2, right: 2, top: 7 })
-
       Text('默认校区')
         .fontSize(13)
         .fontColor(AppTheme.secondaryText())
@@ -311,7 +261,7 @@ export struct SettingsView {
 
   @Builder
   field(placeholder: string, value: string, inputType: InputType,
-    onChangeValue: (value: string) => void) {
+    onChangeValue: (value: string) => void, enabled: boolean = true) {
     TextInput({ placeholder: placeholder, text: value })
       .type(inputType)
       .fontSize(15)
@@ -324,10 +274,85 @@ export struct SettingsView {
       .width('100%')
       .height(36)
       .showPasswordIcon(false)
-      .enabled(!this.model.isSampleMode())
+      .enabled(!this.model.isSampleMode() && enabled)
+      .opacity(this.model.isSampleMode() || !enabled ? 0.62 : 1)
       .onChange((text: string) => {
         onChangeValue(text);
       })
+  }
+
+  // 学期设置独立卡片（对齐 Android SettingsPage.semesterSurface）：
+  // 自动检测开关 + 手动学期字段（自动检测开启时禁用）+ 说明 + 保存学期设置。
+  @Builder
+  semesterSurface() {
+    Column() {
+      this.sectionTitle('学期设置')
+      Row({ space: 8 }) {
+        Text('自动检测当前学期')
+          .fontSize(15)
+          .fontColor(AppTheme.text())
+          .layoutWeight(1)
+        Toggle({ type: ToggleType.Switch, isOn: this.model.automaticTermDetection })
+          .selectedColor(AppTheme.primaryFill())
+          .width(48)
+          .height(28)
+          .enabled(!this.model.isSampleMode())
+          .onChange((value: boolean) => {
+            this.model.automaticTermDetection = value;
+          })
+      }
+      .width('100%')
+      .constraintSize({ minHeight: 36 })
+      .alignItems(VerticalAlign.Center)
+
+      Blank().height(7)
+      this.field('学期编号', this.model.termID, InputType.Normal, (value: string): void => {
+        this.model.termID = value;
+      }, !this.model.automaticTermDetection)
+      Blank().height(7)
+      this.field('第一周周一（YYYY-MM-DD）', this.model.termStartDate, InputType.Normal,
+        (value: string): void => {
+          this.model.termStartDate = value;
+        }, !this.model.automaticTermDetection)
+
+      Text(this.model.automaticTermDetection ?
+        '获取/刷新课表后会自动应用教务返回的学期与开学日期。' :
+        '关闭自动检测后，将使用手动填写的学期信息。')
+        .fontSize(12)
+        .fontColor(AppTheme.secondaryText())
+        .lineHeight(17)
+        .width('100%')
+        .padding({ left: 2, right: 2, top: 8 })
+
+      Blank().height(this.isCompact() ? 10 : 12)
+      Button('保存学期设置')
+        .type(ButtonType.Normal)
+        .stateEffect(true)
+        .fontSize(15)
+        .fontWeight(FontWeight.Bold)
+        .fontColor(AppTheme.primary())
+        .borderRadius(6)
+        .border({ width: 1, color: AppTheme.primary() })
+        .backgroundColor(AppTheme.surface())
+        .width('100%')
+        .height(36)
+        .clickEffect({ level: ClickEffectLevel.MIDDLE, scale: 0.98 })
+        .onClick(() => {
+          const work: Promise<boolean> = this.model.saveSemesterSettings();
+          work.then((saved: boolean) => {
+            if (saved) {
+              this.dismissStatusMessageAfter(this.model.statusMessage);
+            }
+          }).catch(() => {
+            // 错误说明已由 AppModel 写入状态消息。
+          });
+        })
+    }
+    .padding(16)
+    .width('100%')
+    .borderRadius(8)
+    .backgroundColor(AppTheme.surface())
+    .alignItems(HorizontalAlign.Start)
   }
 
   @Builder

--- a/native/harmony/entry/src/main/ets/view/SettingsView.ets
+++ b/native/harmony/entry/src/main/ets/view/SettingsView.ets
@@ -6,12 +6,17 @@ import { AdaptiveLayoutPolicy } from '../common/DeviceState';
 import { AppContext } from '../store/AppContext';
 import { SemesterLogic, SemesterSuggestion } from '../common/SemesterLogic';
 import { PrivacyPolicyView } from './PrivacyPolicyView';
+import {
+  TodayCourseWidgetData, WidgetCoursePreferences, WidgetArchive, CoursePhase
+} from '../widget/TodayCourseWidgetData';
 
 @ComponentV2
 export struct SettingsView {
   @Consumer('appModel') model: AppModel = new AppModel();
   @Local contentWidth: number = 350;
   @Local showingPrivacyPolicy: boolean = false;
+  // 样式预览容量（紧凑 1 / 标准 3 / 展开 6，对应 Android 预览 Spinner）。
+  @Local previewCapacity: number = 3;
   private statusDismissRevision: number = 0;
 
   private static readonly projectURL: string =
@@ -74,6 +79,7 @@ export struct SettingsView {
 
             Column({ space: 16 }) {
               this.notificationSurface()
+              this.widgetSurface()
               this.localDataSurface()
             }
             .layoutWeight(1)
@@ -87,6 +93,7 @@ export struct SettingsView {
             this.accountSurface()
             this.semesterSurface()
             this.notificationSurface()
+            this.widgetSurface()
             this.localDataSurface()
             this.aboutSurface()
           }
@@ -353,6 +360,249 @@ export struct SettingsView {
     .borderRadius(8)
     .backgroundColor(AppTheme.surface())
     .alignItems(HorizontalAlign.Start)
+  }
+
+  // 桌面小组件设置卡片（对齐 Android widgetSurface）：
+  // 显示课程地点/任课教师开关 + 课程数量 + 样式预览。
+  @Builder
+  widgetSurface() {
+    Column() {
+      this.sectionTitle('桌面小组件')
+
+      Row({ space: 8 }) {
+        Text('显示课程地点')
+          .fontSize(15)
+          .fontColor(AppTheme.text())
+          .layoutWeight(1)
+        Toggle({ type: ToggleType.Switch, isOn: this.model.widgetShowsLocation })
+          .selectedColor(AppTheme.primaryFill())
+          .width(48)
+          .height(28)
+          .enabled(!this.model.isSampleMode())
+          .onChange((value: boolean) => {
+            this.model.setWidgetShowsLocation(value);
+          })
+      }
+      .width('100%')
+      .constraintSize({ minHeight: 36 })
+      .alignItems(VerticalAlign.Center)
+
+      Row({ space: 8 }) {
+        Text('显示任课教师')
+          .fontSize(15)
+          .fontColor(AppTheme.text())
+          .layoutWeight(1)
+        Toggle({ type: ToggleType.Switch, isOn: this.model.widgetShowsTeacher })
+          .selectedColor(AppTheme.primaryFill())
+          .width(48)
+          .height(28)
+          .enabled(!this.model.isSampleMode())
+          .onChange((value: boolean) => {
+            this.model.setWidgetShowsTeacher(value);
+          })
+      }
+      .width('100%')
+      .constraintSize({ minHeight: 36 })
+      .alignItems(VerticalAlign.Center)
+
+      Text('显示课程数量')
+        .fontSize(13)
+        .fontColor(AppTheme.secondaryText())
+        .width('100%')
+        .padding({ top: this.isCompact() ? 10 : 14, bottom: 5 })
+      Select([{ value: '1 门' }, { value: '2 门' }, { value: '3 门' }, { value: '4 门' },
+        { value: '5 门' }, { value: '6 门' }])
+        .selected(this.model.widgetCourseLimit - 1)
+        .value(this.model.widgetCourseLimit.toString() + ' 门')
+        .font({ size: 15 })
+        .fontColor(AppTheme.text())
+        .selectedOptionBgColor(AppTheme.primaryFill())
+        .selectedOptionFont({ size: 15, weight: FontWeight.Medium })
+        .selectedOptionFontColor(AppTheme.onPrimary())
+        .optionBgColor(AppTheme.surface())
+        .optionFont({ size: 15 })
+        .optionFontColor(AppTheme.text())
+        .backgroundColor(AppTheme.surface())
+        .border({ width: 1, color: AppTheme.border() })
+        .borderRadius(6)
+        .height(36)
+        .width('100%')
+        .clickEffect({ level: ClickEffectLevel.MIDDLE, scale: 0.98 })
+        .onSelect((index: number) => {
+          this.model.setWidgetCourseLimit(index + 1);
+        })
+
+      Divider()
+        .strokeWidth(1)
+        .color(AppTheme.border())
+        .margin({ top: 14, bottom: 12 })
+
+      Text('样式预览 · 示例内容')
+        .fontSize(14)
+        .fontWeight(FontWeight.Bold)
+        .fontColor(AppTheme.text())
+        .width('100%')
+      Select([{ value: '紧凑' }, { value: '标准' }, { value: '展开' }])
+        .selected(this.previewCapacity === 1 ? 0 : (this.previewCapacity === 6 ? 2 : 1))
+        .value(this.previewCapacity === 1 ? '紧凑' : (this.previewCapacity === 6 ? '展开' : '标准'))
+        .font({ size: 15 })
+        .fontColor(AppTheme.text())
+        .selectedOptionBgColor(AppTheme.primaryFill())
+        .selectedOptionFont({ size: 15, weight: FontWeight.Medium })
+        .selectedOptionFontColor(AppTheme.onPrimary())
+        .optionBgColor(AppTheme.surface())
+        .optionFont({ size: 15 })
+        .optionFontColor(AppTheme.text())
+        .backgroundColor(AppTheme.surface())
+        .border({ width: 1, color: AppTheme.border() })
+        .borderRadius(6)
+        .height(36)
+        .width('100%')
+        .margin({ top: 7 })
+        .clickEffect({ level: ClickEffectLevel.MIDDLE, scale: 0.98 })
+        .onSelect((index: number) => {
+          this.previewCapacity = index === 0 ? 1 : (index === 2 ? 6 : 3);
+        })
+
+      this.widgetPreview()
+    }
+    .padding(16)
+    .width('100%')
+    .borderRadius(8)
+    .backgroundColor(AppTheme.surface())
+    .alignItems(HorizontalAlign.Start)
+  }
+
+  // 样式预览：用示例归档 + 当前偏好生成绑定数据并渲染（对应 Android 预览）。
+  @Builder
+  widgetPreview() {
+    Column() {
+      this.widgetPreviewRow(
+        this.previewString('todayTitle'), this.previewString('todayCountText'),
+        this.previewString('dateContext'), this.previewString('statusText'),
+        this.previewString('course1Name'), this.previewString('course1Details'),
+        this.previewBoolean('course1Highlighted'),
+        this.previewString('course2Name'), this.previewString('course2Details'),
+        this.previewBoolean('course2Highlighted'),
+        this.previewString('course3Name'), this.previewString('course3Details'),
+        this.previewBoolean('course3Highlighted'),
+        this.previewString('course4Name'), this.previewString('course4Details'),
+        this.previewBoolean('course4Highlighted'),
+        this.previewString('course5Name'), this.previewString('course5Details'),
+        this.previewBoolean('course5Highlighted'),
+        this.previewString('course6Name'), this.previewString('course6Details'),
+        this.previewBoolean('course6Highlighted'))
+    }
+    .padding(14)
+    .margin({ top: 8 })
+    .width('100%')
+    .height(this.previewCapacity === 1 ? 130 :
+      (this.previewCapacity === 6 ? 300 : 205))
+    .borderRadius(16)
+    .backgroundColor(AppTheme.surface())
+    .border({ width: 1, color: AppTheme.border() })
+    .alignItems(HorizontalAlign.Start)
+    .clip(true)
+  }
+
+  private previewData(): Record<string, Object> {
+    const prefs: WidgetCoursePreferences = new WidgetCoursePreferences(
+      this.model.widgetShowsLocation, this.model.widgetShowsTeacher,
+      Math.min(this.model.widgetCourseLimit, this.previewCapacity));
+    return TodayCourseWidgetData.binding(
+      TodayCourseWidgetData.previewArchive(), prefs, undefined,
+      TodayCourseWidgetData.nowMinute());
+  }
+
+  private previewString(key: string): string {
+    return String(this.previewData()[key] ?? '');
+  }
+
+  private previewBoolean(key: string): boolean {
+    return this.previewData()[key] === true;
+  }
+
+  @Builder
+  widgetPreviewRow(title: string, count: string, context: string, status: string,
+    n1: string, d1: string, h1: boolean, n2: string, d2: string, h2: boolean,
+    n3: string, d3: string, h3: boolean, n4: string, d4: string, h4: boolean,
+    n5: string, d5: string, h5: boolean, n6: string, d6: string, h6: boolean) {
+    Row() {
+      Text(title)
+        .fontSize(15)
+        .fontWeight(FontWeight.Bold)
+        .fontColor(AppTheme.text())
+      Blank()
+      Text(count)
+        .fontSize(11)
+        .fontWeight(FontWeight.Medium)
+        .fontColor(AppTheme.secondaryText())
+    }
+    .width('100%')
+    .height(26)
+    .alignItems(VerticalAlign.Center)
+    Text(context.length > 0 && status.length > 0 ? context + ' · ' + status : context)
+      .fontSize(11)
+      .fontColor(AppTheme.secondaryText())
+      .maxLines(1)
+      .textOverflow({ overflow: TextOverflow.Ellipsis })
+      .width('100%')
+      .margin({ top: 2 })
+    Blank().height(6)
+    Column({ space: 0 }) {
+      if (n1.length > 0) {
+        this.widgetPreviewRowItem(n1, d1, h1)
+      }
+      if (n2.length > 0) {
+        this.widgetPreviewRowItem(n2, d2, h2)
+      }
+      if (n3.length > 0) {
+        this.widgetPreviewRowItem(n3, d3, h3)
+      }
+      if (n4.length > 0) {
+        this.widgetPreviewRowItem(n4, d4, h4)
+      }
+      if (n5.length > 0) {
+        this.widgetPreviewRowItem(n5, d5, h5)
+      }
+      if (n6.length > 0) {
+        this.widgetPreviewRowItem(n6, d6, h6)
+      }
+    }
+    .width('100%')
+    .alignItems(HorizontalAlign.Start)
+  }
+
+  @Builder
+  widgetPreviewRowItem(name: string, details: string, highlighted: boolean) {
+    Row() {
+      Column()
+        .width(3)
+        .height(26)
+        .borderRadius(1.5)
+        .backgroundColor(highlighted ? AppTheme.primaryFill() : AppTheme.accent())
+      Column({ space: 1 }) {
+        Text(name)
+          .fontSize(13)
+          .fontWeight(FontWeight.Bold)
+          .fontColor(AppTheme.text())
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .width('100%')
+        Text(details)
+          .fontSize(10)
+          .fontColor(AppTheme.secondaryText())
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .width('100%')
+      }
+      .layoutWeight(1)
+      .alignItems(HorizontalAlign.Start)
+      .margin({ left: 8 })
+    }
+    .width('100%')
+    .height(34)
+    .alignItems(VerticalAlign.Center)
   }
 
   @Builder

--- a/native/harmony/entry/src/main/ets/view/calendar/CalendarLogic.ets
+++ b/native/harmony/entry/src/main/ets/view/calendar/CalendarLogic.ets
@@ -1,7 +1,31 @@
 // 教学日历的纯逻辑与时间线布局，以原生 Android 实现为移动端基准。
 // TeachingCalendarLogic / CalendarTimelineLogic / CalendarTimelineDay。
+import { mediaquery } from '@kit.ArkUI';
 import { Course, HolidayItem, SlotMetadata } from '../../common/Models';
 import { StrictDates, DateParts } from '../../common/StrictDates';
+
+// 深色模式探测：Android Palette 按 uiMode 取色，月/年课程填充色需要在代码里
+// 完成混色（对应 UiSupport.kt blend(primary, background, opacity)），
+// 无法仅靠资源色，因此需要感知当前深浅色模式。
+export class DarkModeProbe {
+  private listener: mediaquery.MediaQueryListener | null = null;
+
+  register(callback: (dark: boolean) => void): void {
+    this.unregister();
+    this.listener = mediaquery.matchMediaSync('(dark-mode: true)');
+    callback(this.listener.matches);
+    this.listener.on('change', (result: mediaquery.MediaQueryResult) => {
+      callback(result.matches);
+    });
+  }
+
+  unregister(): void {
+    if (this.listener !== null) {
+      this.listener.off('change');
+      this.listener = null;
+    }
+  }
+}
 
 export enum CalendarMode {
   day = '日',

--- a/native/harmony/entry/src/main/ets/view/calendar/ExpandedTeachingCalendarView.ets
+++ b/native/harmony/entry/src/main/ets/view/calendar/ExpandedTeachingCalendarView.ets
@@ -9,7 +9,7 @@ import { AppTheme } from '../../common/AppTheme';
 import { PageTitle } from '../SharedComponents';
 import {
   CalendarFormatters, CalendarMode, CalendarModeInfo, CalendarTimelineDay,
-  CalendarTimelineLogic, TeachingCalendarLogic
+  CalendarTimelineLogic, DarkModeProbe, TeachingCalendarLogic
 } from './CalendarLogic';
 import { TeachingCalendarSession } from './TeachingCalendarSession';
 import { CoursePlacement, MobileCalendarTimelineView } from './MobileCalendarTimelineView';
@@ -33,11 +33,20 @@ export struct ExpandedTeachingCalendarView {
   @Local presentedDay: DateParts | null = null;
   @Local contentWidth: number = 900;
   @Local contentHeight: number = 700;
+  @Local isDarkMode: boolean = false;
+  private darkModeProbe: DarkModeProbe = new DarkModeProbe();
   private timelinePlacements: Map<string, CoursePlacement[]> =
     new Map<string, CoursePlacement[]>();
 
   aboutToAppear(): void {
     this.ensureVisibleHolidays();
+    this.darkModeProbe.register((dark: boolean) => {
+      this.isDarkMode = dark;
+    });
+  }
+
+  aboutToDisappear(): void {
+    this.darkModeProbe.unregister();
   }
 
   @Monitor('session.selectedDate')
@@ -335,6 +344,7 @@ export struct ExpandedTeachingCalendarView {
           placements: this.timelinePlacements,
           selectedDate: this.selectedDate(),
           showsWeekColumns: this.mode() === CalendarMode.week,
+          expanded: true,
           onSelectDay: (day: DateParts): void => {
             this.setSelectedDate(day);
           }
@@ -373,10 +383,10 @@ export struct ExpandedTeachingCalendarView {
             Text(CalendarFormatters.monthDayCompact(entry.day) + ' · ' + entry.item.name)
               .fontSize(12)
               .fontWeight(FontWeight.Medium)
-              .fontColor(entry.item.type === 'holiday' ? AppTheme.danger() : AppTheme.primary())
+              .fontColor(entry.item.type === 'holiday' ? AppTheme.holiday() : AppTheme.primary())
               .padding({ left: 10, right: 10, top: 5, bottom: 5 })
               .borderRadius(12)
-              .backgroundColor('#14166B5D')
+              .backgroundColor('#140C4A42')
               .onClick(() => {
                 this.setSelectedDate(entry.day);
               })
@@ -428,11 +438,9 @@ export struct ExpandedTeachingCalendarView {
           }, (day: DateParts) => 'month-day.' + StrictDates.formatDateParts(day))
       }
       .columnsTemplate('repeat(7, 1fr)')
-      .columnsGap(4)
-      .rowsGap(4)
+      .columnsGap(2)
+      .rowsGap(2)
       .width('100%')
-
-      this.daySummaryCard(this.selectedDate())
     }
     .width('100%')
   }
@@ -447,28 +455,31 @@ export struct ExpandedTeachingCalendarView {
         .width('100%')
         .textAlign(TextAlign.Center)
         .padding({ top: 3 })
-      Column({ space: 2 }) {
+      Column({ space: 1 }) {
         ForEach(this.monthEvents(day).slice(0, 2), (event: MonthEventItem) => {
           Text(event.title)
             .fontSize(10)
             .fontWeight(FontWeight.Medium)
             .fontColor(day.equals(this.selectedDate()) ? AppTheme.onPrimary() : event.tint)
             .maxLines(1)
+            .textOverflow({ overflow: TextOverflow.Ellipsis })
             .padding({ left: 3, right: 3 })
             .width('100%')
             .height(14)
-            .textAlign(TextAlign.Center)
-            .backgroundColor('#C7FFFFFF')
-            .borderRadius(4)
-            .border({ width: 0.75, color: AppTheme.border() })
+            .textAlign(TextAlign.Start)
+            .backgroundColor(day.equals(this.selectedDate()) ?
+              AppTheme.primaryDark() : Color.Transparent)
+            .borderRadius(3)
         }, (event: MonthEventItem) => 'month-event.' + event.id)
         if (this.monthEvents(day).length > 2) {
           Text('+' + (this.monthEvents(day).length - 2).toString())
             .fontSize(10)
+            .fontWeight(FontWeight.Medium)
             .fontColor(day.equals(this.selectedDate()) ? AppTheme.onPrimary() : AppTheme.secondaryText())
             .width('100%')
-            .height(14)
-            .textAlign(TextAlign.Center)
+            .height(13)
+            .textAlign(TextAlign.Start)
+            .padding({ left: 2, right: 2 })
         }
       }
       .width('100%')
@@ -476,14 +487,14 @@ export struct ExpandedTeachingCalendarView {
     }
     .padding({ left: 2, right: 2, bottom: 2 })
     .width('100%')
-    .height(76)
-    .borderRadius(5)
+    .height(82)
+    .borderRadius(9)
     .backgroundColor(day.equals(this.selectedDate()) ?
       AppTheme.primaryFill() : this.monthBackground(day))
     .border({
-      width: day.equals(StrictDates.todayParts()) && !day.equals(this.selectedDate()) ? 2 : 1,
+      width: day.equals(StrictDates.todayParts()) && !day.equals(this.selectedDate()) ? 2 : 0,
       color: day.equals(StrictDates.todayParts()) && !day.equals(this.selectedDate()) ?
-        AppTheme.danger() : AppTheme.border()
+        AppTheme.nowIndicator() : Color.Transparent
     })
     .clip(true)
     .onClick(() => {
@@ -496,7 +507,7 @@ export struct ExpandedTeachingCalendarView {
     for (const item of this.holidayItemsOn(day)) {
       result.push(new MonthEventItem(
         'holiday-' + item.id(), (item.type === 'holiday' ? '休 ' : '班 ') + item.name,
-        item.type === 'holiday' ? AppTheme.danger() : AppTheme.primary()));
+        item.type === 'holiday' ? AppTheme.holiday() : AppTheme.primary()));
     }
     for (const course of this.coursesOn(day)) {
       result.push(new MonthEventItem('course-' + course.id, course.name, AppTheme.primary()));
@@ -515,7 +526,7 @@ export struct ExpandedTeachingCalendarView {
     if (items.length === 0) {
       return AppTheme.text();
     }
-    return items[0].type === 'holiday' ? AppTheme.danger() : AppTheme.primary();
+    return items[0].type === 'holiday' ? AppTheme.holiday() : AppTheme.primary();
   }
 
   private monthBackground(day: DateParts): ResourceColor {
@@ -524,7 +535,7 @@ export struct ExpandedTeachingCalendarView {
       return Color.Transparent;
     }
     const alpha: number = Math.min(0.08 + count * 0.08, 0.36);
-    return CalendarColors.primaryWithAlpha(alpha);
+    return CalendarColors.primaryWithAlpha(alpha, this.isDarkMode);
   }
 
   @Builder
@@ -555,13 +566,14 @@ export struct ExpandedTeachingCalendarView {
   }
 
   private yearColumnCount(): number {
-    if (this.contentWidth >= 1080) {
-      return 5;
-    }
-    if (this.contentWidth >= 880) {
+    // 对齐 Android YearCalendarView：>=1060 -> 4，>=660 -> 3，否则 2。
+    if (this.contentWidth >= 1060) {
       return 4;
     }
-    return 3;
+    if (this.contentWidth >= 660) {
+      return 3;
+    }
+    return 2;
   }
 
   private monthsOfYear(): number[] {
@@ -611,17 +623,19 @@ export struct ExpandedTeachingCalendarView {
   yearDayButton(day: DateParts, month: number) {
     if (day.month === month) {
       Text(day.day.toString())
-        .fontSize(8)
-        .fontColor(AppTheme.text())
+        .fontSize(9)
+        .fontColor(day.equals(this.selectedDate()) ? AppTheme.onPrimary() : AppTheme.text())
         .textAlign(TextAlign.Center)
         .width('100%')
-        .height(24)
-        .borderRadius(4)
-        .backgroundColor(CalendarColors.primaryWithAlpha(
-          TeachingCalendarLogic.yearCourseOpacity(this.coursesOn(day).length)))
+        .height(30)
+        .borderRadius(3)
+        .backgroundColor(day.equals(this.selectedDate()) ?
+          AppTheme.primaryFill() : CalendarColors.primaryWithAlpha(
+            TeachingCalendarLogic.yearCourseOpacity(this.coursesOn(day).length), this.isDarkMode))
         .border({
-          width: day.equals(StrictDates.todayParts()) ? 2 : 0.5,
-          color: day.equals(StrictDates.todayParts()) ? AppTheme.primary() : AppTheme.border()
+          width: day.equals(StrictDates.todayParts()) && !day.equals(this.selectedDate()) ? 2 : 0,
+          color: day.equals(StrictDates.todayParts()) && !day.equals(this.selectedDate()) ?
+            AppTheme.nowIndicator() : Color.Transparent
         })
         .onClick(() => {
           this.setSelectedDate(day);
@@ -697,7 +711,7 @@ export struct ExpandedTeachingCalendarView {
         Text((item.type === 'holiday' ? '休 ' : '班 ') + item.name)
           .fontSize(13)
           .fontWeight(FontWeight.Medium)
-          .fontColor(item.type === 'holiday' ? AppTheme.danger() : AppTheme.primary())
+          .fontColor(item.type === 'holiday' ? AppTheme.holiday() : AppTheme.primary())
       }, (item: HolidayItem) => 'summary-holiday.' + item.id())
       if (this.coursesOn(day).length === 0) {
         Text('暂无课程')
@@ -743,10 +757,18 @@ class AllDayEntry {
   }
 }
 
+// 主题主色与背景的混色（对应 Android UiSupport.kt blend(primary, background, amount)）：
+// 深浅色分别用 app_primary / app_background 的十六进制计算不透明结果。
 class CalendarColors {
-  static primaryWithAlpha(alpha: number): string {
+  static primaryWithAlpha(alpha: number, dark: boolean): string {
     const clamped: number = Math.min(Math.max(alpha, 0), 1);
-    const hexAlpha: string = Math.round(clamped * 255).toString(16).padStart(2, '0');
-    return '#' + hexAlpha.toUpperCase() + '166B5D';
+    const fg: number[] = dark ? [0x5A, 0xD2, 0xB8] : [0x16, 0x6B, 0x5D];
+    const bg: number[] = dark ? [0x00, 0x00, 0x00] : [0xF2, 0xF2, 0xF7];
+    const channels: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const v: number = Math.round(bg[i] + (fg[i] - bg[i]) * clamped);
+      channels.push(v.toString(16).padStart(2, '0'));
+    }
+    return '#' + channels.join('').toUpperCase();
   }
 }

--- a/native/harmony/entry/src/main/ets/view/calendar/ExpandedTeachingCalendarView.ets
+++ b/native/harmony/entry/src/main/ets/view/calendar/ExpandedTeachingCalendarView.ets
@@ -496,8 +496,11 @@ export struct ExpandedTeachingCalendarView {
     .backgroundColor(day.equals(this.selectedDate()) ?
       AppTheme.primaryFill() : this.monthBackground(day))
     .border({
-      width: day.equals(StrictDates.todayParts()) && !day.equals(this.selectedDate()) ? 2 : 0,
-      color: day.equals(StrictDates.todayParts()) && !day.equals(this.selectedDate()) ?
+      // PC（Tauri）今日环在选中时也显示；平板（Android）仅未选中时显示红环。
+      width: day.equals(StrictDates.todayParts()) &&
+        (this.isPc || !day.equals(this.selectedDate())) ? 2 : 0,
+      color: day.equals(StrictDates.todayParts()) &&
+        (this.isPc || !day.equals(this.selectedDate())) ?
         AppTheme.nowIndicator() : Color.Transparent
     })
     .clip(true)
@@ -534,6 +537,10 @@ export struct ExpandedTeachingCalendarView {
   }
 
   private monthBackground(day: DateParts): ResourceColor {
+    // PC（Tauri）格底为 surface 白底；平板（Android）无课时为透明（页面背景透出）。
+    if (this.isPc && this.coursesOn(day).length <= 0) {
+      return AppTheme.surface();
+    }
     const count: number = this.coursesOn(day).length;
     if (count <= 0) {
       return Color.Transparent;

--- a/native/harmony/entry/src/main/ets/view/calendar/ExpandedTeachingCalendarView.ets
+++ b/native/harmony/entry/src/main/ets/view/calendar/ExpandedTeachingCalendarView.ets
@@ -6,6 +6,7 @@ import { AppModel } from '../../model/AppModel';
 import { Course, HolidayItem } from '../../common/Models';
 import { StrictDates, DateParts } from '../../common/StrictDates';
 import { AppTheme } from '../../common/AppTheme';
+import { DeviceState } from '../../common/DeviceState';
 import { PageTitle } from '../SharedComponents';
 import {
   CalendarFormatters, CalendarMode, CalendarModeInfo, CalendarTimelineDay,
@@ -34,6 +35,8 @@ export struct ExpandedTeachingCalendarView {
   @Local contentWidth: number = 900;
   @Local contentHeight: number = 700;
   @Local isDarkMode: boolean = false;
+  // PC（2in1）按 Windows Tauri 布局；平板/折叠屏按 Android 折叠屏布局。
+  @Local isPc: boolean = DeviceState.isPc2in1();
   private darkModeProbe: DarkModeProbe = new DarkModeProbe();
   private timelinePlacements: Map<string, CoursePlacement[]> =
     new Map<string, CoursePlacement[]>();
@@ -345,6 +348,7 @@ export struct ExpandedTeachingCalendarView {
           selectedDate: this.selectedDate(),
           showsWeekColumns: this.mode() === CalendarMode.week,
           expanded: true,
+          tauri: this.isPc,
           onSelectDay: (day: DateParts): void => {
             this.setSelectedDate(day);
           }
@@ -438,8 +442,8 @@ export struct ExpandedTeachingCalendarView {
           }, (day: DateParts) => 'month-day.' + StrictDates.formatDateParts(day))
       }
       .columnsTemplate('repeat(7, 1fr)')
-      .columnsGap(2)
-      .rowsGap(2)
+      .columnsGap(this.isPc ? 4 : 2)
+      .rowsGap(this.isPc ? 4 : 2)
       .width('100%')
     }
     .width('100%')
@@ -485,10 +489,10 @@ export struct ExpandedTeachingCalendarView {
       .width('100%')
       .alignItems(HorizontalAlign.Start)
     }
-    .padding({ left: 2, right: 2, bottom: 2 })
+    .padding({ left: this.isPc ? 4 : 2, right: this.isPc ? 4 : 2, bottom: this.isPc ? 4 : 2 })
     .width('100%')
-    .height(82)
-    .borderRadius(9)
+    .height(this.isPc ? 96 : 82)
+    .borderRadius(this.isPc ? 5 : 9)
     .backgroundColor(day.equals(this.selectedDate()) ?
       AppTheme.primaryFill() : this.monthBackground(day))
     .border({

--- a/native/harmony/entry/src/main/ets/view/calendar/MobileCalendarTimelineView.ets
+++ b/native/harmony/entry/src/main/ets/view/calendar/MobileCalendarTimelineView.ets
@@ -51,6 +51,9 @@ export struct MobileCalendarTimelineView {
   @Param days: CalendarTimelineDay[] = [];
   @Param selectedDate: DateParts = StrictDates.todayParts();
   @Param showsWeekColumns: boolean = false;
+  // 宽屏（平板/PC）形态：与 Android CalendarTimelineView 的 expanded 参数对应。
+  // 宽屏显示日头行（72vp）、课程节次轴（96vp）、小时高 68vp、最小日宽 156vp。
+  @Param expanded: boolean = false;
   // 各天课程布局缓存（BUG-046 修复）：由父组件在构造 days 时一次算好。
   @Param placements: Map<string, CoursePlacement[]> = new Map<string, CoursePlacement[]>();
   @Event onSelectDay: (day: DateParts) => void = () => {
@@ -97,6 +100,47 @@ export struct MobileCalendarTimelineView {
 
   private dayWidthValue(): number {
     return this.viewportWidth / this.dayCount();
+  }
+
+  // 宽屏布局数值（对齐 Android CalendarTimelineLogic 的 expanded 参数）：
+  // axisWidth = 48 小时轴 + 96 节次轴；小时高 68；日头高 72；最小日宽 156。
+  private axisWidth(): number {
+    return this.expanded ? 144 : MobileCalendarTimelineLayout.axisWidth;
+  }
+
+  private hourAxisWidth(): number {
+    return 48;
+  }
+
+  private slotAxisWidth(): number {
+    return this.expanded ? 96 : 0;
+  }
+
+  private hourHeight(): number {
+    return this.expanded ? 68 : MobileCalendarTimelineLayout.hourHeight;
+  }
+
+  private headerHeight(): number {
+    return this.expanded ? 72 : 0;
+  }
+
+  private bodyHeight(): number {
+    return (MobileCalendarTimelineLayout.endMinute - MobileCalendarTimelineLayout.startMinute) / 60 *
+      this.hourHeight();
+  }
+
+  private totalHeight(): number {
+    return this.headerHeight() + this.bodyHeight();
+  }
+
+  private yPos(minute: number): number {
+    const clamped: number = Math.min(Math.max(minute, MobileCalendarTimelineLayout.startMinute),
+      MobileCalendarTimelineLayout.endMinute);
+    return (clamped - MobileCalendarTimelineLayout.startMinute) / 60 * this.hourHeight();
+  }
+
+  private dayWidthMin(): number {
+    return this.expanded ? 156 : 0;
   }
 
   private shanghaiMinuteOfDay(): number {
@@ -156,135 +200,150 @@ export struct MobileCalendarTimelineView {
   }
 
   build() {
-    Stack({ alignContent: Alignment.TopStart }) {
-      // 小时轴
-      Column() {
-        ForEach(this.hours, (hour: number) => {
-          if (!this.hourLabelObscured(hour)) {
-            Text(CalendarFormatters.hourLabel(hour))
-              .fontSize(9)
-              .fontColor(AppTheme.secondaryText())
-              .width(MobileCalendarTimelineLayout.axisWidth - 8)
-              .textAlign(TextAlign.Center)
-              .position({
-                x: 0,
-                y: MobileCalendarTimelineLayout.yPosition(hour * 60) + this.adjustedHourLabelY(hour)
-              })
-          }
-        }, (hour: number) => 'hour-label.' + hour.toString())
-        if (this.isNowVisible()) {
-          Text(this.timeLabel())
-            .fontSize(10)
-            .fontWeight(FontWeight.Medium)
-            .fontColor(AppTheme.onPrimary())
-            .width(40)
-            .height(18)
-            .textAlign(TextAlign.Center)
-            .borderRadius(9)
-            .backgroundColor(AppTheme.danger())
-            .position({ x: 4, y: this.indicatorY() - 9 })
-        }
+    Column() {
+      // 宽屏日头行（对齐 Android expanded 的 72vp day header + Tauri .time-day-head）
+      if (this.expanded) {
+        this.dayHeaderRow()
       }
-      .width(MobileCalendarTimelineLayout.axisWidth)
-      .height(MobileCalendarTimelineLayout.timelineHeight)
-      .alignItems(HorizontalAlign.Start)
-
-      // 右侧网格视口
       Stack({ alignContent: Alignment.TopStart }) {
-        // 小时线
-        ForEach(this.hours, (hour: number) => {
-          Divider()
-            .strokeWidth(0.5)
-            .color(AppTheme.border())
-            .width(this.viewportWidth)
-            .position({ x: 0, y: MobileCalendarTimelineLayout.yPosition(hour * 60) })
-        }, (hour: number) => 'grid-hour.' + hour.toString())
+        // 小时轴
+        Column() {
+          ForEach(this.hours, (hour: number) => {
+            if (!this.hourLabelObscured(hour)) {
+              Text(CalendarFormatters.hourLabel(hour))
+                .fontSize(9)
+                .fontColor(AppTheme.secondaryText())
+                .width(this.hourAxisWidth() - 8)
+                .textAlign(TextAlign.Center)
+                .position({
+                  x: 0,
+                  y: this.yPos(hour * 60) + this.adjustedHourLabelY(hour)
+                })
+            }
+          }, (hour: number) => 'hour-label.' + hour.toString())
+          if (this.isNowVisible()) {
+            Text(this.timeLabel())
+              .fontSize(10)
+              .fontWeight(FontWeight.Medium)
+              .fontColor(AppTheme.onPrimary())
+              .width(40)
+              .height(18)
+              .textAlign(TextAlign.Center)
+              .borderRadius(9)
+              .backgroundColor(AppTheme.nowIndicator())
+              .position({ x: 4, y: this.indicatorY() - 9 })
+          }
+        }
+        .width(this.hourAxisWidth())
+        .height(this.bodyHeight())
+        .alignItems(HorizontalAlign.Start)
 
-        // 课程节次边界使用更清晰的虚线，避免在深色模式和周视图窄列中消失。
-        ForEach(CalendarTimelineLogic.nonHourlyCourseBoundaryMinutes(), (minute: number) => {
-          Column()
-            .width(this.viewportWidth)
-            .height(2)
-            .border({
-              width: { top: 1.2 },
-              color: AppTheme.border(),
-              style: BorderStyle.Dashed
-            })
-            .opacity(0.56)
-            .position({ x: 0, y: MobileCalendarTimelineLayout.yPosition(minute) })
-        }, (minute: number) => 'grid-slot.' + minute.toString())
+        // 宽屏课程节次轴（对应 Android 96vp slot axis / Tauri .slot-time-labels）
+        if (this.expanded) {
+          ForEach(SlotMetadata.defaults, (slot: SlotMetadata) => {
+            this.slotAxisLabel(slot)
+          }, (slot: SlotMetadata) => 'slot-axis.' + slot.index.toString())
+        }
 
-        // 周视图列分隔线
-        if (this.showsWeekColumns) {
-          ForEach(this.days, (day: CalendarTimelineDay, index: number) => {
+        // 右侧网格视口
+        Stack({ alignContent: Alignment.TopStart }) {
+          // 小时线
+          ForEach(this.hours, (hour: number) => {
             Divider()
-              .vertical(true)
               .strokeWidth(0.5)
               .color(AppTheme.border())
-              .opacity(0.7)
-              .height(MobileCalendarTimelineLayout.timelineHeight)
-              .position({ x: index * this.dayWidthValue(), y: 0 })
-          }, (day: CalendarTimelineDay) => 'grid-column.' + this.dayKey(day))
-        }
+              .width(this.viewportWidth)
+              .position({ x: 0, y: this.yPos(hour * 60) })
+          }, (hour: number) => 'grid-hour.' + hour.toString())
 
-        // 选中列高亮
-        if (this.showsWeekColumns) {
-          ForEach(this.days, (day: CalendarTimelineDay, index: number) => {
-            if (day.date.equals(this.selectedDate)) {
+          // 课程节次边界使用更清晰的虚线，避免在深色模式和周视图窄列中消失。
+          ForEach(CalendarTimelineLogic.nonHourlyCourseBoundaryMinutes(), (minute: number) => {
+            Column()
+              .width(this.viewportWidth)
+              .height(2)
+              .border({
+                width: { top: 1.2 },
+                color: AppTheme.border(),
+                style: BorderStyle.Dashed
+              })
+              .opacity(0.56)
+              .position({ x: 0, y: this.yPos(minute) })
+          }, (minute: number) => 'grid-slot.' + minute.toString())
+
+          // 周视图列分隔线
+          if (this.showsWeekColumns) {
+            ForEach(this.days, (day: CalendarTimelineDay, index: number) => {
+              Divider()
+                .vertical(true)
+                .strokeWidth(0.5)
+                .color(AppTheme.border())
+                .opacity(0.7)
+                .height(this.bodyHeight())
+                .position({ x: index * this.dayWidthValue(), y: 0 })
+            }, (day: CalendarTimelineDay) => 'grid-column.' + this.dayKey(day))
+          }
+
+          // 选中列高亮
+          if (this.showsWeekColumns) {
+            ForEach(this.days, (day: CalendarTimelineDay, index: number) => {
+              if (day.date.equals(this.selectedDate)) {
+                Column()
+                  .width(this.dayWidthValue())
+                  .height(this.bodyHeight())
+                  .backgroundColor('#0B166B5D')
+                  .hitTestBehavior(HitTestMode.None)
+                  .position({ x: index * this.dayWidthValue(), y: 0 })
+              }
+            }, (day: CalendarTimelineDay) => 'selected-column.' + this.dayKey(day))
+          }
+
+          // 单日模式的节次胶囊
+          if (!this.showsWeekColumns) {
+            ForEach(SlotMetadata.defaults, (slot: SlotMetadata) => {
+              this.slotGuide(slot)
+            }, (slot: SlotMetadata) => 'slot-guide.' + slot.index.toString())
+          }
+
+          // 课程块
+          ForEach(this.days, (day: CalendarTimelineDay, dayIndex: number) => {
+            ForEach(this.placementsOf(day), (placement: CoursePlacement) => {
+              this.courseBlock(dayIndex, placement)
+            }, (placement: CoursePlacement) => this.dayKey(day) + '|' + placement.course.id + '|' +
+              placement.track.toString())
+          }, (day: CalendarTimelineDay) => 'day-blocks.' + this.dayKey(day))
+
+          // 当前时间指示
+          if (this.isNowVisible()) {
+            this.currentTimeIndicator()
+          }
+
+          // 周视图列点击
+          if (this.showsWeekColumns) {
+            ForEach(this.days, (day: CalendarTimelineDay, index: number) => {
               Column()
                 .width(this.dayWidthValue())
-                .height(MobileCalendarTimelineLayout.timelineHeight)
-                .backgroundColor('#0B166B5D')
-                .hitTestBehavior(HitTestMode.None)
+                .height(this.bodyHeight())
+                .backgroundColor(Color.Transparent)
                 .position({ x: index * this.dayWidthValue(), y: 0 })
-            }
-          }, (day: CalendarTimelineDay) => 'selected-column.' + this.dayKey(day))
+                .onClick(() => {
+                  this.onSelectDay(day.date);
+                })
+            }, (day: CalendarTimelineDay) => 'column-click.' + this.dayKey(day))
+          }
         }
-
-        // 单日模式的节次胶囊
-        if (!this.showsWeekColumns) {
-          ForEach(SlotMetadata.defaults, (slot: SlotMetadata) => {
-            this.slotGuide(slot)
-          }, (slot: SlotMetadata) => 'slot-guide.' + slot.index.toString())
-        }
-
-        // 课程块
-        ForEach(this.days, (day: CalendarTimelineDay, dayIndex: number) => {
-          ForEach(this.placementsOf(day), (placement: CoursePlacement) => {
-            this.courseBlock(dayIndex, placement)
-          }, (placement: CoursePlacement) => this.dayKey(day) + '|' + placement.course.id + '|' +
-            placement.track.toString())
-        }, (day: CalendarTimelineDay) => 'day-blocks.' + this.dayKey(day))
-
-        // 当前时间指示
-        if (this.isNowVisible()) {
-          this.currentTimeIndicator()
-        }
-
-        // 周视图列点击
-        if (this.showsWeekColumns) {
-          ForEach(this.days, (day: CalendarTimelineDay, index: number) => {
-            Column()
-              .width(this.dayWidthValue())
-              .height(MobileCalendarTimelineLayout.timelineHeight)
-              .backgroundColor(Color.Transparent)
-              .position({ x: index * this.dayWidthValue(), y: 0 })
-              .onClick(() => {
-                this.onSelectDay(day.date);
-              })
-          }, (day: CalendarTimelineDay) => 'column-click.' + this.dayKey(day))
-        }
+        .width(this.viewportWidth)
+        .height(this.bodyHeight())
+        .position({ x: this.axisWidth(), y: 0 })
+        .clip(true)
       }
-      .width(this.viewportWidth)
-      .height(MobileCalendarTimelineLayout.timelineHeight)
-      .position({ x: MobileCalendarTimelineLayout.axisWidth, y: 0 })
-      .clip(true)
+      .width('100%')
+      .height(this.bodyHeight())
     }
     .width('100%')
-    .height(MobileCalendarTimelineLayout.timelineHeight)
+    .height(this.totalHeight())
     .backgroundColor(AppTheme.surface())
     .onAreaChange((oldArea: Area, newArea: Area) => {
-      this.viewportWidth = Math.max(Number(newArea.width) - MobileCalendarTimelineLayout.axisWidth, 1);
+      this.viewportWidth = Math.max(Number(newArea.width) - this.axisWidth(), 1);
     })
     .onVisibleAreaChange([0.0, 1.0], (isVisible: boolean, currentRatio: number): void => {
       this.viewVisible = isVisible;
@@ -294,6 +353,86 @@ export struct MobileCalendarTimelineView {
         this.stopTimer();
       }
     })
+  }
+
+  // 宽屏日头行：左侧角标（整点/课程节次）+ 每天日头（星期 + 月/日 + 课程数）。
+  @Builder
+  dayHeaderRow() {
+    Row({ space: 0 }) {
+      Row() {
+        Text('整点')
+          .fontSize(10)
+          .fontWeight(FontWeight.Bold)
+          .fontColor(AppTheme.secondaryText())
+          .textAlign(TextAlign.Center)
+          .width(this.hourAxisWidth())
+        Text('课程节次')
+          .fontSize(10)
+          .fontWeight(FontWeight.Bold)
+          .fontColor(AppTheme.secondaryText())
+          .textAlign(TextAlign.Center)
+          .width(this.slotAxisWidth())
+      }
+      .width(this.axisWidth())
+      .height(this.headerHeight())
+      .justifyContent(FlexAlign.Center)
+      .border({ width: { bottom: 1, right: 1 }, color: AppTheme.border() })
+
+      ForEach(this.days, (day: CalendarTimelineDay, index: number) => {
+        Column({ space: 3 }) {
+          Row({ space: 4 }) {
+            Text(CalendarFormatters.weekdayLabels[StrictDates.weekdayMonday1(day.date) - 1])
+              .fontSize(12)
+              .fontWeight(FontWeight.Bold)
+              .fontColor(AppTheme.text())
+            Text(day.date.month.toString() + '/' + day.date.day.toString())
+              .fontSize(12)
+              .fontWeight(FontWeight.Bold)
+              .fontColor(AppTheme.text())
+          }
+          Text(day.courses.length === 0 ? '无课程' :
+            day.courses.length.toString() + ' 门课')
+            .fontSize(10)
+            .fontColor(day.courses.length > 0 ? AppTheme.primary() : AppTheme.secondaryText())
+            .maxLines(1)
+        }
+        .width(this.dayWidthValue())
+        .height(this.headerHeight())
+        .justifyContent(FlexAlign.Center)
+        .border({ width: { left: 1, bottom: 1 }, color: AppTheme.border() })
+        .backgroundColor(day.date.equals(this.selectedDate) ? '#0B166B5D' : AppTheme.surface())
+        .onClick(() => {
+          this.onSelectDay(day.date);
+        })
+      }, (day: CalendarTimelineDay) => 'day-head.' + this.dayKey(day))
+    }
+    .width('100%')
+    .height(this.headerHeight())
+  }
+
+  // 宽屏课程节次轴标签：第 N 节（bold）+ 起止时间。
+  @Builder
+  slotAxisLabel(slot: SlotMetadata) {
+    Column({ space: 1 }) {
+      Text('第' + slot.label + '节')
+        .fontSize(11)
+        .fontWeight(FontWeight.Bold)
+        .fontColor(AppTheme.secondaryText())
+        .maxLines(1)
+      Text(slot.start + '-' + slot.end)
+        .fontSize(9)
+        .fontColor(AppTheme.secondaryText())
+        .maxLines(1)
+    }
+    .width(this.slotAxisWidth())
+    .alignItems(HorizontalAlign.Center)
+    .position({ x: this.hourAxisWidth(), y: this.slotAxisCenterY(slot) })
+  }
+
+  private slotAxisCenterY(slot: SlotMetadata): number {
+    const startMinute: number = CalendarTimelineLogic.minuteOf(slot.start) ?? 0;
+    const endMinute: number = CalendarTimelineLogic.minuteOf(slot.end) ?? 0;
+    return (this.yPos(startMinute) + this.yPos(endMinute)) / 2 - 10;
   }
 
   @Builder
@@ -314,8 +453,7 @@ export struct MobileCalendarTimelineView {
   private slotGuideY(slot: SlotMetadata): number {
     const startMinute: number = CalendarTimelineLogic.minuteOf(slot.start) ?? 0;
     const endMinute: number = CalendarTimelineLogic.minuteOf(slot.end) ?? 0;
-    return (MobileCalendarTimelineLayout.yPosition(startMinute) +
-      MobileCalendarTimelineLayout.yPosition(endMinute)) / 2 - 9;
+    return (this.yPos(startMinute) + this.yPos(endMinute)) / 2 - 9;
   }
 
   @Builder
@@ -419,13 +557,13 @@ export struct MobileCalendarTimelineView {
   }
 
   private blockTop(course: Course): number {
-    return MobileCalendarTimelineLayout.yPosition(this.blockStartMinute(course)) + 2;
+    return this.yPos(this.blockStartMinute(course)) + 2;
   }
 
   private blockHeight(course: Course): number {
     const top: number = this.blockTop(course);
     const bottom: number = Math.max(top + 38,
-      MobileCalendarTimelineLayout.yPosition(this.blockEndMinute(course)) - 2);
+      this.yPos(this.blockEndMinute(course)) - 2);
     return bottom - top;
   }
 
@@ -471,14 +609,14 @@ export struct MobileCalendarTimelineView {
     Column() {
       Divider()
         .strokeWidth(2)
-        .color(AppTheme.danger())
+        .color(AppTheme.nowIndicator())
         .width(this.indicatorWidth())
         .position({ x: this.indicatorLeft(), y: 0 })
       Column()
         .width(8)
         .height(8)
         .borderRadius(4)
-        .backgroundColor(AppTheme.danger())
+        .backgroundColor(AppTheme.nowIndicator())
         .position({ x: this.indicatorLeft(), y: -3 })
     }
     .width(this.viewportWidth)
@@ -505,7 +643,7 @@ export struct MobileCalendarTimelineView {
   }
 
   private indicatorY(): number {
-    return MobileCalendarTimelineLayout.yPosition(this.shanghaiMinuteOfDay());
+    return this.yPos(this.shanghaiMinuteOfDay());
   }
 
   private isNowVisible(): boolean {

--- a/native/harmony/entry/src/main/ets/view/calendar/MobileCalendarTimelineView.ets
+++ b/native/harmony/entry/src/main/ets/view/calendar/MobileCalendarTimelineView.ets
@@ -410,6 +410,14 @@ export struct MobileCalendarTimelineView {
             .fontSize(10)
             .fontColor(day.courses.length > 0 ? AppTheme.primary() : AppTheme.secondaryText())
             .maxLines(1)
+          // 今日红条：日头底部 3vp systemRed 横条（对应 Tauri inset 0 -3px 0 #FF3B30）。
+          if (day.date.equals(StrictDates.todayParts())) {
+            Column()
+              .width('100%')
+              .height(3)
+              .backgroundColor(AppTheme.nowIndicator())
+              .position({ x: 0, y: this.headerHeight() - 3 })
+          }
         }
         .width(this.dayWidthValue())
         .height(this.headerHeight())

--- a/native/harmony/entry/src/main/ets/view/calendar/MobileCalendarTimelineView.ets
+++ b/native/harmony/entry/src/main/ets/view/calendar/MobileCalendarTimelineView.ets
@@ -52,8 +52,11 @@ export struct MobileCalendarTimelineView {
   @Param selectedDate: DateParts = StrictDates.todayParts();
   @Param showsWeekColumns: boolean = false;
   // 宽屏（平板/PC）形态：与 Android CalendarTimelineView 的 expanded 参数对应。
-  // 宽屏显示日头行（72vp）、课程节次轴（96vp）、小时高 68vp、最小日宽 156vp。
+  // 宽屏显示日头行（72vp）、课程节次轴、小时高、最小日宽。
   @Param expanded: boolean = false;
+  // PC（2in1）使用 Windows Tauri 数值（轴 52+104、时高 64、最小日宽 118）；
+  // 平板/折叠屏使用 Android 数值（轴 48+96、时高 68、最小日宽 156）。
+  @Param tauri: boolean = false;
   // 各天课程布局缓存（BUG-046 修复）：由父组件在构造 days 时一次算好。
   @Param placements: Map<string, CoursePlacement[]> = new Map<string, CoursePlacement[]>();
   @Event onSelectDay: (day: DateParts) => void = () => {
@@ -99,25 +102,34 @@ export struct MobileCalendarTimelineView {
   }
 
   private dayWidthValue(): number {
-    return this.viewportWidth / this.dayCount();
+    return Math.max(this.viewportWidth / this.dayCount(), this.dayWidthMin());
   }
 
   // 宽屏布局数值（对齐 Android CalendarTimelineLogic 的 expanded 参数）：
   // axisWidth = 48 小时轴 + 96 节次轴；小时高 68；日头高 72；最小日宽 156。
   private axisWidth(): number {
-    return this.expanded ? 144 : MobileCalendarTimelineLayout.axisWidth;
+    if (!this.expanded) {
+      return MobileCalendarTimelineLayout.axisWidth;
+    }
+    return this.tauri ? 156 : 144;
   }
 
   private hourAxisWidth(): number {
-    return 48;
+    return this.expanded ? (this.tauri ? 52 : 48) : 48;
   }
 
   private slotAxisWidth(): number {
-    return this.expanded ? 96 : 0;
+    if (!this.expanded) {
+      return 0;
+    }
+    return this.tauri ? 104 : 96;
   }
 
   private hourHeight(): number {
-    return this.expanded ? 68 : MobileCalendarTimelineLayout.hourHeight;
+    if (!this.expanded) {
+      return MobileCalendarTimelineLayout.hourHeight;
+    }
+    return this.tauri ? 64 : 68;
   }
 
   private headerHeight(): number {
@@ -140,7 +152,10 @@ export struct MobileCalendarTimelineView {
   }
 
   private dayWidthMin(): number {
-    return this.expanded ? 156 : 0;
+    if (!this.expanded) {
+      return 0;
+    }
+    return this.tauri ? 118 : 156;
   }
 
   private shanghaiMinuteOfDay(): number {

--- a/native/harmony/entry/src/main/ets/view/calendar/MobileTeachingCalendarView.ets
+++ b/native/harmony/entry/src/main/ets/view/calendar/MobileTeachingCalendarView.ets
@@ -9,7 +9,7 @@ import { AppTheme } from '../../common/AppTheme';
 import { PageTitle, SurfaceCard } from '../SharedComponents';
 import {
   CalendarFormatters, CalendarMode, CalendarModeInfo, CalendarTimelineDay,
-  CalendarTimelineLogic, TeachingCalendarLogic
+  CalendarTimelineLogic, DarkModeProbe, TeachingCalendarLogic
 } from './CalendarLogic';
 import { TeachingCalendarSession } from './TeachingCalendarSession';
 import { MobileCalendarTimelineLayout, MobileCalendarTimelineView } from './MobileCalendarTimelineView';
@@ -39,6 +39,8 @@ export struct MobileTeachingCalendarView {
   @Local contentHeight: number = 500;
   @Local rootWidth: number = 350;
   @Local rootHeight: number = 640;
+  @Local isDarkMode: boolean = false;
+  private darkModeProbe: DarkModeProbe = new DarkModeProbe();
   @Local rootGlobalX: number = 0;
   @Local rootGlobalY: number = 0;
   @Local presentedDayAnchorX: number = 175;
@@ -61,9 +63,13 @@ export struct MobileTeachingCalendarView {
       TeachingCalendarLogic.monthSheetExpandedPosition :
       TeachingCalendarLogic.monthSheetDetailsPosition;
     this.ensureVisibleHolidays();
+    this.darkModeProbe.register((dark: boolean) => {
+      this.isDarkMode = dark;
+    });
   }
 
   aboutToDisappear(): void {
+    this.darkModeProbe.unregister();
     // 清理延迟滚动定时器，避免对已销毁 Scroller 操作（BUG-012 修复）。
     if (this.timelineScrollTimer >= 0) {
       clearTimeout(this.timelineScrollTimer);
@@ -562,7 +568,7 @@ export struct MobileTeachingCalendarView {
     if (holiday === null) {
       return AppTheme.text();
     }
-    return holiday.type === 'holiday' ? AppTheme.danger() : AppTheme.primary();
+    return holiday.type === 'holiday' ? AppTheme.holiday() : AppTheme.primary();
   }
 
   private firstHoliday(day: DateParts): HolidayItem | null {
@@ -753,7 +759,7 @@ export struct MobileTeachingCalendarView {
   private allDayForeground(day: CalendarTimelineDay): ResourceColor {
     for (const item of day.holidays) {
       if (item.type === 'holiday') {
-        return AppTheme.danger();
+        return AppTheme.holiday();
       }
     }
     return AppTheme.primary();
@@ -935,7 +941,7 @@ export struct MobileTeachingCalendarView {
     .border({
       width: day.equals(StrictDates.todayParts()) && !day.equals(renderDate) ? 2 : 0,
       color: day.equals(StrictDates.todayParts()) && !day.equals(renderDate) ?
-        AppTheme.primary() : Color.Transparent
+        AppTheme.nowIndicator() : Color.Transparent
     })
     .clip(true)
     .onClick(() => {
@@ -1078,7 +1084,7 @@ export struct MobileTeachingCalendarView {
     if (holiday === null) {
       return AppTheme.text();
     }
-    return holiday.type === 'holiday' ? AppTheme.danger() : AppTheme.primary();
+    return holiday.type === 'holiday' ? AppTheme.holiday() : AppTheme.primary();
   }
 
   private monthBackground(day: DateParts, renderDate: DateParts): ResourceColor {
@@ -1090,7 +1096,7 @@ export struct MobileTeachingCalendarView {
       return Color.Transparent;
     }
     const alpha: number = Math.min(0.08 + count * 0.08, 0.36);
-    return CalendarColors.primaryWithAlpha(alpha);
+    return CalendarColors.primaryWithAlpha(alpha, this.isDarkMode);
   }
 
   // ---------- 年视图 ----------
@@ -1196,10 +1202,11 @@ export struct MobileTeachingCalendarView {
         .borderRadius(4)
         .backgroundColor(this.presentedDay !== null && day.equals(this.presentedDay as DateParts) ?
           AppTheme.primaryFill() : CalendarColors.primaryWithAlpha(
-            TeachingCalendarLogic.yearCourseOpacity(this.coursesOn(day).length)))
+            TeachingCalendarLogic.yearCourseOpacity(this.coursesOn(day).length), this.isDarkMode))
         .border({
-          width: day.equals(StrictDates.todayParts()) ? 2 : 0.5,
-          color: day.equals(StrictDates.todayParts()) ? AppTheme.primary() : AppTheme.border()
+          width: day.equals(StrictDates.todayParts()) && !day.equals(this.presentedDay) ? 2 : 0,
+          color: day.equals(StrictDates.todayParts()) && !day.equals(this.presentedDay) ?
+            AppTheme.nowIndicator() : Color.Transparent
         })
         .onClick((event: ClickEvent) => {
           if (!interactive) {
@@ -1341,11 +1348,11 @@ export struct MobileTeachingCalendarView {
           SymbolGlyph(item.type === 'holiday' ? $r('sys.symbol.calendar_badge_clock') :
             $r('sys.symbol.briefcase'))
             .fontSize(14)
-            .fontColor([item.type === 'holiday' ? AppTheme.danger() : AppTheme.primary()])
+            .fontColor([item.type === 'holiday' ? AppTheme.holiday() : AppTheme.primary()])
           Text(item.name)
             .fontSize(14)
             .fontWeight(FontWeight.Medium)
-            .fontColor(item.type === 'holiday' ? AppTheme.danger() : AppTheme.primary())
+            .fontColor(item.type === 'holiday' ? AppTheme.holiday() : AppTheme.primary())
         }
         .width('100%')
       }, (item: HolidayItem) => 'summary-holiday.' + item.id())
@@ -1501,9 +1508,15 @@ class AllDayEntry {
 
 // 主题主色的透明度变体（供月/年单元格背景使用；深浅色下均可用）。
 class CalendarColors {
-  static primaryWithAlpha(alpha: number): string {
+  static primaryWithAlpha(alpha: number, dark: boolean): string {
     const clamped: number = Math.min(Math.max(alpha, 0), 1);
-    const hexAlpha: string = Math.round(clamped * 255).toString(16).padStart(2, '0');
-    return '#' + hexAlpha.toUpperCase() + '166B5D';
+    const fg: number[] = dark ? [0x5A, 0xD2, 0xB8] : [0x16, 0x6B, 0x5D];
+    const bg: number[] = dark ? [0x00, 0x00, 0x00] : [0xF2, 0xF2, 0xF7];
+    const channels: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const v: number = Math.round(bg[i] + (fg[i] - bg[i]) * clamped);
+      channels.push(v.toString(16).padStart(2, '0'));
+    }
+    return '#' + channels.join('').toUpperCase();
   }
 }

--- a/native/harmony/entry/src/main/ets/widget/TodayCourseWidgetAbility.ets
+++ b/native/harmony/entry/src/main/ets/widget/TodayCourseWidgetAbility.ets
@@ -3,16 +3,17 @@
 import { formBindingData, FormExtensionAbility, formProvider } from '@kit.FormKit';
 import { Want } from '@kit.AbilityKit';
 import { WidgetSync } from './WidgetSync';
-import { TodayCourseWidgetData, WidgetArchive } from './TodayCourseWidgetData';
+import { TodayCourseWidgetData, WidgetArchive, WidgetCoursePreferences } from './TodayCourseWidgetData';
 
 export default class TodayCourseWidgetAbility extends FormExtensionAbility {
-  // 卡片尺寸 → 课程行数（2*2 两行，其余三行；未知按三行），BUG-040 修复。
-  private static courseLimitForDimension(dimension: Object | undefined): number {
+  // 卡片尺寸 → 行数上限（2*2 两行，其余按偏好上限；未知按偏好上限），BUG-040 修复。
+  private static rowLimitForDimension(dimension: Object | undefined,
+    preferences: WidgetCoursePreferences): number {
     const value: number = typeof dimension === 'number' ? dimension as number : Number(dimension);
     if (!Number.isNaN(value) && value === 1) {
-      return 2;
+      return Math.min(2, preferences.courseLimit);
     }
-    return 3;
+    return preferences.courseLimit;
   }
 
   onAddForm(want: Want): formBindingData.FormBindingData {
@@ -20,9 +21,11 @@ export default class TodayCourseWidgetAbility extends FormExtensionAbility {
     const archive: WidgetArchive | null = WidgetSync.loadArchiveSync(
       TodayCourseWidgetData.archiveFilePath(this.context.filesDir));
     const dimension: Object | undefined = want.parameters?.['ohos.extra.param.key.form_dimension'];
+    const preferences: WidgetCoursePreferences =
+      archive?.preferences ?? new WidgetCoursePreferences();
     return formBindingData.createFormBindingData(
-      TodayCourseWidgetData.binding(archive,
-        TodayCourseWidgetAbility.courseLimitForDimension(dimension)));
+      TodayCourseWidgetData.binding(archive, preferences,
+        undefined, TodayCourseWidgetData.nowMinute()));
   }
 
   onUpdateForm(formId: string, wantParams?: Record<string, Object>): void {
@@ -33,12 +36,15 @@ export default class TodayCourseWidgetAbility extends FormExtensionAbility {
     wantParams?: Record<string, Object>): void {
     const filesDir: string = this.context.filesDir;
     const dimension: Object | undefined = wantParams?.['ohos.extra.param.key.form_dimension'];
-    const courseLimit: number = TodayCourseWidgetAbility.courseLimitForDimension(dimension);
     const work: Promise<void> = (async (): Promise<void> => {
       const archive: WidgetArchive | null = await WidgetSync.loadArchive(
         TodayCourseWidgetData.archiveFilePath(filesDir));
+      const preferences: WidgetCoursePreferences =
+        archive?.preferences ?? new WidgetCoursePreferences();
       const data: formBindingData.FormBindingData =
-        formBindingData.createFormBindingData(TodayCourseWidgetData.binding(archive, courseLimit));
+        formBindingData.createFormBindingData(
+          TodayCourseWidgetData.binding(archive, preferences,
+            undefined, TodayCourseWidgetData.nowMinute()));
       if (hasFormId) {
         try {
           await formProvider.updateForm(formId, data);

--- a/native/harmony/entry/src/main/ets/widget/TodayCourseWidgetData.ets
+++ b/native/harmony/entry/src/main/ets/widget/TodayCourseWidgetData.ets
@@ -84,25 +84,33 @@ export class TodayCourseWidgetData {
 
   // 卡片绑定数据：今天课程条目 + 明日提示 + 空态文案。
   // courseLimit 按卡片尺寸传入（2*2 两行，其余三行），BUG-040 修复。
-  static binding(archive: WidgetArchive | null, courseLimit: number = 3): Record<string, Object> {
-    const today: DateParts = StrictDates.todayParts();
+  // today 可注入便于测试（默认取上海时区当天）。
+  static binding(archive: WidgetArchive | null, courseLimit: number = 3,
+    today: DateParts = StrictDates.todayParts()): Record<string, Object> {
     const todayCourses: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(today, archive);
     const tomorrowCourses: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(
       StrictDates.addDays(today, 1), archive);
-    const lines: string[] = [];
     const limit: number = Math.max(1, courseLimit);
+    // 逐行课程数据：对应 Android 卡片的 WidgetCourseName/WidgetCourseDetails，
+    // 详情为 "时间 · 教室"（无教室则仅时间），最多 3 行由卡片渲染。
+    const rows: string[][] = [];
     for (let i = 0; i < Math.min(todayCourses.length, limit); i++) {
       const course: WidgetArchiveCourse = todayCourses[i];
-      const parts: string[] = [course.timeRange, course.name];
+      const details: string[] = [course.timeRange];
       if (course.room.length > 0) {
-        parts.push('@ ' + course.room);
+        details.push(course.room);
       }
-      lines.push(parts.join(' '));
+      rows.push([course.name, details.join(' · ')]);
     }
     const out: Record<string, Object> = {};
     out['todayTitle'] = '今日课程';
     out['todayCountText'] = todayCourses.length === 0 ? '' : todayCourses.length.toString() + ' 门';
-    out['todayLines'] = lines.join('\n');
+    out['course1Name'] = rows.length > 0 ? rows[0][0] : '';
+    out['course1Details'] = rows.length > 0 ? rows[0][1] : '';
+    out['course2Name'] = rows.length > 1 ? rows[1][0] : '';
+    out['course2Details'] = rows.length > 1 ? rows[1][1] : '';
+    out['course3Name'] = rows.length > 2 ? rows[2][0] : '';
+    out['course3Details'] = rows.length > 2 ? rows[2][1] : '';
     out['moreHint'] = todayCourses.length > limit ?
       '另有 ' + (todayCourses.length - limit).toString() + ' 门课程' : '';
     out['tomorrowHint'] = tomorrowCourses.length === 0 ?

--- a/native/harmony/entry/src/main/ets/widget/TodayCourseWidgetData.ets
+++ b/native/harmony/entry/src/main/ets/widget/TodayCourseWidgetData.ets
@@ -1,4 +1,5 @@
-// 今日课程卡片的数据层，对应 iOS 端 TodayCourseWidgetData.swift。
+// 今日课程卡片的数据层，对应 iOS 端 TodayCourseWidgetData.swift 与
+// Android 端 TodayCourseWidget.kt（课程状态/高亮/上下文/预览增强版）。
 // 应用侧写入精简归档 widget-schedule.json（与沙箱课表同目录），
 // 卡片侧（FormExtensionAbility）从同一沙箱读取，无需跨进程通道。
 import { ScheduleSnapshot } from '../common/Models';
@@ -8,18 +9,23 @@ import { StrictDates, DateParts } from '../common/StrictDates';
 export class WidgetArchiveCourse {
   readonly id: string;
   readonly name: string;
+  readonly teacher: string;
   readonly room: string;
+  readonly sectionText: string;
   readonly timeRange: string;
   readonly weekday: number;
   readonly weekNumbers: number[];
   readonly examWeekNumbers: number[];
   readonly startSlot: number;
 
-  constructor(id: string, name: string, room: string, timeRange: string, weekday: number,
-    weekNumbers: number[], examWeekNumbers: number[], startSlot: number) {
+  constructor(id: string, name: string, teacher: string, room: string, sectionText: string,
+    timeRange: string, weekday: number, weekNumbers: number[], examWeekNumbers: number[],
+    startSlot: number) {
     this.id = id;
     this.name = name;
+    this.teacher = teacher;
     this.room = room;
+    this.sectionText = sectionText;
     this.timeRange = timeRange;
     this.weekday = weekday;
     this.weekNumbers = weekNumbers;
@@ -32,12 +38,55 @@ export class WidgetArchive {
   readonly termStartDate: string;
   readonly fetchedAt: string;
   readonly courses: WidgetArchiveCourse[];
+  readonly preferences: WidgetCoursePreferences;
 
-  constructor(termStartDate: string, fetchedAt: string, courses: WidgetArchiveCourse[]) {
+  constructor(termStartDate: string, fetchedAt: string, courses: WidgetArchiveCourse[],
+    preferences: WidgetCoursePreferences = new WidgetCoursePreferences()) {
     this.termStartDate = termStartDate;
     this.fetchedAt = fetchedAt;
     this.courses = courses;
+    this.preferences = preferences;
   }
+}
+
+// 卡片显示偏好（对应 Android widgetShowsLocation/widgetShowsTeacher/widgetCourseLimit）。
+export class WidgetCoursePreferences {
+  static readonly defaultLimit: number = 4;
+  static readonly maximumLimit: number = 6;
+
+  readonly showsLocation: boolean;
+  readonly showsTeacher: boolean;
+  readonly courseLimit: number;
+
+  constructor(showsLocation: boolean = true, showsTeacher: boolean = true,
+    courseLimit: number = WidgetCoursePreferences.defaultLimit) {
+    this.showsLocation = showsLocation;
+    this.showsTeacher = showsTeacher;
+    this.courseLimit = Math.min(Math.max(courseLimit, 1), WidgetCoursePreferences.maximumLimit);
+  }
+
+  static fromJson(raw: Record<string, Object>): WidgetCoursePreferences {
+    return new WidgetCoursePreferences(
+      typeof raw['shows_location'] === 'boolean' ? raw['shows_location'] as boolean : true,
+      typeof raw['shows_teacher'] === 'boolean' ? raw['shows_teacher'] as boolean : true,
+      typeof raw['course_limit'] === 'number' ? raw['course_limit'] as number :
+      WidgetCoursePreferences.defaultLimit);
+  }
+
+  toJson(): Record<string, Object> {
+    const out: Record<string, Object> = {};
+    out['shows_location'] = this.showsLocation;
+    out['shows_teacher'] = this.showsTeacher;
+    out['course_limit'] = this.courseLimit;
+    return out;
+  }
+}
+
+// 课程在当前时刻的阶段（对应 Android WidgetCoursePhase）。
+export enum CoursePhase {
+  upcoming = 0,
+  inProgress = 1,
+  finished = 2
 }
 
 export class TodayCourseWidgetData {
@@ -47,14 +96,16 @@ export class TodayCourseWidgetData {
     return filesDir + '/WhereToStudyNative/' + TodayCourseWidgetData.archiveFileName;
   }
 
-  static scheduleToArchive(schedule: ScheduleSnapshot): WidgetArchive {
+  static scheduleToArchive(schedule: ScheduleSnapshot,
+    preferences: WidgetCoursePreferences = new WidgetCoursePreferences()): WidgetArchive {
     const courses: WidgetArchiveCourse[] = [];
     for (const course of schedule.courses) {
       courses.push(new WidgetArchiveCourse(
-        course.id, course.name, course.room, course.timeRange, course.weekday,
-        course.weekNumbers, course.examWeekNumbers, course.startSlot));
+        course.id, course.name, course.teacher, course.room, course.sectionText,
+        course.timeRange, course.weekday, course.weekNumbers, course.examWeekNumbers,
+        course.startSlot));
     }
-    return new WidgetArchive(schedule.termStartDate, schedule.fetchedAt, courses);
+    return new WidgetArchive(schedule.termStartDate, schedule.fetchedAt, courses, preferences);
   }
 
   static coursesOn(date: DateParts, archive: WidgetArchive | null): WidgetArchiveCourse[] {
@@ -82,49 +133,204 @@ export class TodayCourseWidgetData {
     return result;
   }
 
-  // 卡片绑定数据：今天课程条目 + 明日提示 + 空态文案。
-  // courseLimit 按卡片尺寸传入（2*2 两行，其余三行），BUG-040 修复。
-  // today 可注入便于测试（默认取上海时区当天）。
-  static binding(archive: WidgetArchive | null, courseLimit: number = 3,
-    today: DateParts = StrictDates.todayParts()): Record<string, Object> {
-    const todayCourses: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(today, archive);
-    const tomorrowCourses: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(
-      StrictDates.addDays(today, 1), archive);
-    const limit: number = Math.max(1, courseLimit);
-    // 逐行课程数据：对应 Android 卡片的 WidgetCourseName/WidgetCourseDetails，
-    // 详情为 "时间 · 教室"（无教室则仅时间），最多 3 行由卡片渲染。
-    const rows: string[][] = [];
-    for (let i = 0; i < Math.min(todayCourses.length, limit); i++) {
-      const course: WidgetArchiveCourse = todayCourses[i];
-      const details: string[] = [course.timeRange];
-      if (course.room.length > 0) {
-        details.push(course.room);
-      }
-      rows.push([course.name, details.join(' · ')]);
+  // 课程阶段：未来 / 进行中 / 已结束（按上海时区当前时刻判断）。
+  static coursePhase(course: WidgetArchiveCourse, at: DateParts, minute: number): CoursePhase {
+    const start: number | null = TodayCourseWidgetData.minuteOf(course.timeRange, true);
+    const end: number | null = TodayCourseWidgetData.minuteOf(course.timeRange, false);
+    if (start === null || end === null || end < start) {
+      return CoursePhase.finished;
     }
+    if (minute < start) {
+      return CoursePhase.upcoming;
+    }
+    if (minute <= end) {
+      return CoursePhase.inProgress;
+    }
+    return CoursePhase.finished;
+  }
+
+  static minuteOf(value: string, start: boolean): number | null {
+    const normalized: string = value.replace(/[–—]/g, '-');
+    const parts: string[] = normalized.split('-');
+    const target: string = start ? (parts[0] ?? '') : (parts[1] ?? '');
+    const nums: string[] = target.split(':');
+    if (nums.length !== 2) {
+      return null;
+    }
+    const h: number = Number(nums[0]);
+    const m: number = Number(nums[1]);
+    if (!Number.isFinite(h) || !Number.isFinite(m) || h < 0 || h > 23 || m < 0 || m > 59) {
+      return null;
+    }
+    return h * 60 + m;
+  }
+
+  // 高亮课程：优先进行中，其次下一节（对应 Android highlightedCourse）。
+  static highlightedCourse(
+    courses: WidgetArchiveCourse[], minute: number
+  ): WidgetArchiveCourse | null {
+    for (const course of courses) {
+      if (TodayCourseWidgetData.coursePhase(course, StrictDates.todayParts(), minute) ===
+        CoursePhase.inProgress) {
+        return course;
+      }
+    }
+    for (const course of courses) {
+      if (TodayCourseWidgetData.coursePhase(course, StrictDates.todayParts(), minute) ===
+        CoursePhase.upcoming) {
+        return course;
+      }
+    }
+    return null;
+  }
+
+  // 日期上下文："8月21日 · 周五 · 第34周"。
+  static dayContext(date: DateParts, weekNumber: number | null): string {
+    const weekdays: string[] = ['周一', '周二', '周三', '周四', '周五', '周六', '周日'];
+    const parts: string[] = [
+      date.month.toString() + '月' + date.day.toString() + '日',
+      weekdays[StrictDates.weekdayMonday1(date) - 1]
+    ];
+    if (weekNumber !== null) {
+      parts.push('第' + weekNumber.toString() + '周');
+    }
+    return parts.join(' · ');
+  }
+
+  // 状态摘要：进行中·几点下课 / 下一节·几点 / 今日课程已结束 / 今天可以自由安排。
+  static statusSummary(courses: WidgetArchiveCourse[], minute: number): string {
+    if (courses.length === 0) {
+      return '今天可以自由安排';
+    }
+    for (const course of courses) {
+      if (TodayCourseWidgetData.coursePhase(course, StrictDates.todayParts(), minute) ===
+        CoursePhase.inProgress) {
+        const end: string = TodayCourseWidgetData.endTimeOf(course.timeRange);
+        return end.length === 0 ? '课程进行中' : '进行中 · ' + end + ' 下课';
+      }
+    }
+    for (const course of courses) {
+      if (TodayCourseWidgetData.coursePhase(course, StrictDates.todayParts(), minute) ===
+        CoursePhase.upcoming) {
+        const start: string = TodayCourseWidgetData.startTimeOf(course.timeRange);
+        return start.length === 0 ? '还有待上课程' : '下一节 · ' + start;
+      }
+    }
+    return '今日课程已结束';
+  }
+
+  static startTimeOf(value: string): string {
+    const parts: string[] = value.split('-');
+    return parts.length > 0 ? (parts[0] ?? '').trim() : '';
+  }
+
+  static endTimeOf(value: string): string {
+    const parts: string[] = value.split('-');
+    return parts.length > 1 ? (parts[1] ?? '').trim() : '';
+  }
+
+  // 课程标题：高亮时加前缀（进行中 · X / 下一节 · X）。
+  static courseTitle(course: WidgetArchiveCourse, minute: number): string {
+    const phase: CoursePhase = TodayCourseWidgetData.coursePhase(
+      course, StrictDates.todayParts(), minute);
+    if (phase === CoursePhase.inProgress) {
+      return '进行中 · ' + course.name;
+    }
+    if (phase === CoursePhase.upcoming) {
+      return '下一节 · ' + course.name;
+    }
+    return course.name;
+  }
+
+  // 详情："时间 · 节次 · 教室 · 教师"（按偏好裁剪）。
+  static courseDetails(course: WidgetArchiveCourse, prefs: WidgetCoursePreferences): string {
+    const parts: string[] = [];
+    if (course.timeRange.length > 0) {
+      parts.push(course.timeRange);
+    }
+    if (course.sectionText.length > 0) {
+      parts.push(course.sectionText);
+    }
+    if (prefs.showsLocation && course.room.length > 0) {
+      parts.push(course.room);
+    }
+    if (prefs.showsTeacher && course.teacher.length > 0) {
+      parts.push(course.teacher);
+    }
+    return parts.join(' · ');
+  }
+
+  // 卡片绑定数据：日期上下文 + 状态摘要 + 最多 6 行课程（高亮前缀）+ 空态。
+  // courseLimit 来自偏好；today/minute 可注入便于测试。
+  static binding(archive: WidgetArchive | null, prefs: WidgetCoursePreferences,
+    today: DateParts = StrictDates.todayParts(), minute: number = TodayCourseWidgetData.nowMinute()
+  ): Record<string, Object> {
+    const todayCourses: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(today, archive);
+    const week: number | null = archive === null ? null :
+      (ScheduleLogic.weekNumber(today, StrictDates.parseDateString(archive.termStartDate) ?? today));
+    const limit: number = Math.max(1, prefs.courseLimit);
+    const highlighted: WidgetArchiveCourse | null = TodayCourseWidgetData.highlightedCourse(
+      todayCourses, minute);
     const out: Record<string, Object> = {};
     out['todayTitle'] = '今日课程';
     out['todayCountText'] = todayCourses.length === 0 ? '' : todayCourses.length.toString() + ' 门';
-    out['course1Name'] = rows.length > 0 ? rows[0][0] : '';
-    out['course1Details'] = rows.length > 0 ? rows[0][1] : '';
-    out['course2Name'] = rows.length > 1 ? rows[1][0] : '';
-    out['course2Details'] = rows.length > 1 ? rows[1][1] : '';
-    out['course3Name'] = rows.length > 2 ? rows[2][0] : '';
-    out['course3Details'] = rows.length > 2 ? rows[2][1] : '';
+    out['dateContext'] = TodayCourseWidgetData.dayContext(today, week);
+    out['statusText'] = TodayCourseWidgetData.statusSummary(todayCourses, minute);
+    for (let i = 0; i < 6; i++) {
+      const course: WidgetArchiveCourse | undefined = todayCourses[i];
+      const key: string = (i + 1).toString();
+      if (course === undefined || i >= limit) {
+        out['course' + key + 'Name'] = '';
+        out['course' + key + 'Details'] = '';
+        out['course' + key + 'Highlighted'] = false;
+      } else {
+        out['course' + key + 'Name'] = TodayCourseWidgetData.courseTitle(course, minute);
+        out['course' + key + 'Details'] = TodayCourseWidgetData.courseDetails(course, prefs);
+        out['course' + key + 'Highlighted'] = course.id === (highlighted?.id ?? '');
+      }
+    }
     out['moreHint'] = todayCourses.length > limit ?
       '另有 ' + (todayCourses.length - limit).toString() + ' 门课程' : '';
-    out['tomorrowHint'] = tomorrowCourses.length === 0 ?
-      '明天暂无课程' : '明天 ' + tomorrowCourses.length.toString() + ' 门课';
     if (archive === null) {
       out['emptyGlyph'] = '↻';
       out['emptyText'] = '打开应用获取个人课表';
     } else if (todayCourses.length === 0) {
       out['emptyGlyph'] = '✓';
-      out['emptyText'] = '今天没有课程';
+      out['emptyText'] = '今日无课';
     } else {
       out['emptyGlyph'] = '';
       out['emptyText'] = '';
     }
     return out;
+  }
+
+  static nowMinute(): number {
+    const today: DateParts = StrictDates.todayParts();
+    const now: Date = new Date();
+    return now.getHours() * 60 + now.getMinutes();
+  }
+
+  // 设置页样式预览用示例归档（对应 Android previewContent / Apple previewArchive）。
+  static previewArchive(): WidgetArchive {
+    const today: DateParts = StrictDates.todayParts();
+    const weekday: number = StrictDates.weekdayMonday1(today);
+    const courses: WidgetArchiveCourse[] = [];
+    const items: [string, string, string, string, string, number, number][] = [
+      ['高等数学', '示例教师', '教2-101', '1-2节', '08:00-09:35', 0, 1],
+      ['数据挖掘', '示例教师', '教3-335', '3-5节', '09:50-12:15', 2, 4],
+      ['计算机网络', '示例教师', '教4-201', '6-7节', '13:00-14:35', 5, 6],
+      ['神经网络与深度学习', '示例教师', '教3-539', '8-9节', '14:45-16:25', 7, 8],
+      ['体育', '示例教师', '体育馆', '10-11节', '16:35-18:10', 9, 10],
+      ['学术英语', '示例教师', '主楼-201', '12-13节', '18:30-20:05', 11, 12],
+    ];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      courses.push(new WidgetArchiveCourse(
+        'preview-' + i.toString(), item[0], item[1], item[2], item[3], item[4],
+        weekday, [1], [], item[5]));
+    }
+    const termStart: DateParts = StrictDates.addDays(today, 1 - weekday);
+    return new WidgetArchive(StrictDates.formatDateParts(termStart),
+      'widget-preview', courses);
   }
 }

--- a/native/harmony/entry/src/main/ets/widget/WidgetSync.ets
+++ b/native/harmony/entry/src/main/ets/widget/WidgetSync.ets
@@ -7,19 +7,21 @@ import { ScheduleSnapshot } from '../common/Models';
 import { JsonFile } from '../store/JsonFile';
 import { AppContext } from '../store/AppContext';
 import {
-  TodayCourseWidgetData, WidgetArchive, WidgetArchiveCourse
+  TodayCourseWidgetData, WidgetArchive, WidgetArchiveCourse, WidgetCoursePreferences
 } from './TodayCourseWidgetData';
 
 export class WidgetSync {
   // AppModel 在课表保存/清除/加载后调用；失败不影响主流程。
-  static refresh(schedule: ScheduleSnapshot | null): void {
+  static refresh(schedule: ScheduleSnapshot | null,
+    preferences: WidgetCoursePreferences = new WidgetCoursePreferences()): void {
     const work: Promise<void> = (async (): Promise<void> => {
       try {
         const path: string = TodayCourseWidgetData.archiveFilePath(AppContext.filesRoot());
         if (schedule === null) {
           await JsonFile.removeFile(path);
         } else {
-          const archive: WidgetArchive = TodayCourseWidgetData.scheduleToArchive(schedule);
+          const archive: WidgetArchive = TodayCourseWidgetData.scheduleToArchive(
+            schedule, preferences);
           const text: string = JSON.stringify(WidgetSync.archiveToJson(archive));
           await JsonFile.writeTextAtomic(path, text);
         }
@@ -95,7 +97,9 @@ export class WidgetSync {
       courses.push(new WidgetArchiveCourse(
         WidgetSync.asString(record['id']),
         WidgetSync.asString(record['name']),
+        WidgetSync.asString(record['teacher']),
         WidgetSync.asString(record['room']),
+        WidgetSync.asString(record['section_text']),
         WidgetSync.asString(record['time_range']),
         WidgetSync.asNumber(record['weekday']),
         WidgetSync.numberArray(record['week_numbers']),
@@ -103,7 +107,10 @@ export class WidgetSync {
         WidgetSync.asNumber(record['start_slot'])
       ));
     }
-    return new WidgetArchive(termStartDate, fetchedAt, courses);
+    const preferences: WidgetCoursePreferences = typeof raw['preferences'] === 'object' ?
+      WidgetCoursePreferences.fromJson(raw['preferences'] as Record<string, Object>) :
+      new WidgetCoursePreferences();
+    return new WidgetArchive(termStartDate, fetchedAt, courses, preferences);
   }
 
   private static numberArray(value: Object | undefined): number[] {
@@ -136,7 +143,9 @@ export class WidgetSync {
       const item: Record<string, Object> = {};
       item['id'] = course.id;
       item['name'] = course.name;
+      item['teacher'] = course.teacher;
       item['room'] = course.room;
+      item['section_text'] = course.sectionText;
       item['time_range'] = course.timeRange;
       item['weekday'] = course.weekday;
       item['week_numbers'] = course.weekNumbers;
@@ -145,6 +154,7 @@ export class WidgetSync {
       courses.push(item);
     }
     out['courses'] = courses;
+    out['preferences'] = archive.preferences.toJson();
     return out;
   }
 }

--- a/native/harmony/entry/src/main/ets/widget/pages/TodayCourseCard.ets
+++ b/native/harmony/entry/src/main/ets/widget/pages/TodayCourseCard.ets
@@ -1,60 +1,69 @@
-// 今日课程卡片 UI，对应 iOS 端 TodayCourseWidgetView 与
-// Android 端 widget_today_course.xml：标题行 + 最多 3 行课程
-// （金色强调条 + 课程名/时间·教室）+ 更多提示 + 明日提示 + 空态。
+// 今日课程卡片 UI，对应 iOS 端 TodayCourseWidgetCard.swift 与
+// Android 端 widget_today_course.xml（增强版）：
+// 标题行 + 日期/状态上下文 + 最多 6 行课程（高亮前缀 + 强调条）+ 空态。
 // 卡片运行环境仅支持受限 ArkTS 子集，这里只使用基础容器与 Text。
 @Entry
 @Component
 struct TodayCourseCard {
   @LocalStorageProp('todayTitle') todayTitle: string = '今日课程';
   @LocalStorageProp('todayCountText') todayCountText: string = '';
+  @LocalStorageProp('dateContext') dateContext: string = '';
+  @LocalStorageProp('statusText') statusText: string = '';
   @LocalStorageProp('course1Name') course1Name: string = '';
   @LocalStorageProp('course1Details') course1Details: string = '';
+  @LocalStorageProp('course1Highlighted') course1Highlighted: boolean = false;
   @LocalStorageProp('course2Name') course2Name: string = '';
   @LocalStorageProp('course2Details') course2Details: string = '';
+  @LocalStorageProp('course2Highlighted') course2Highlighted: boolean = false;
   @LocalStorageProp('course3Name') course3Name: string = '';
   @LocalStorageProp('course3Details') course3Details: string = '';
+  @LocalStorageProp('course3Highlighted') course3Highlighted: boolean = false;
+  @LocalStorageProp('course4Name') course4Name: string = '';
+  @LocalStorageProp('course4Details') course4Details: string = '';
+  @LocalStorageProp('course4Highlighted') course4Highlighted: boolean = false;
+  @LocalStorageProp('course5Name') course5Name: string = '';
+  @LocalStorageProp('course5Details') course5Details: string = '';
+  @LocalStorageProp('course5Highlighted') course5Highlighted: boolean = false;
+  @LocalStorageProp('course6Name') course6Name: string = '';
+  @LocalStorageProp('course6Details') course6Details: string = '';
+  @LocalStorageProp('course6Highlighted') course6Highlighted: boolean = false;
   @LocalStorageProp('moreHint') moreHint: string = '';
-  @LocalStorageProp('tomorrowHint') tomorrowHint: string = '';
   @LocalStorageProp('emptyGlyph') emptyGlyph: string = '';
   @LocalStorageProp('emptyText') emptyText: string = '';
 
-  private rowNames(): string[] {
-    const names: string[] = [];
+  private rows(): string[][] {
+    const names: string[][] = [];
     if (this.course1Name.length > 0) {
-      names.push(this.course1Name);
+      names.push([this.course1Name, this.course1Details, this.course1Highlighted ? '1' : '0']);
     }
     if (this.course2Name.length > 0) {
-      names.push(this.course2Name);
+      names.push([this.course2Name, this.course2Details, this.course2Highlighted ? '1' : '0']);
     }
     if (this.course3Name.length > 0) {
-      names.push(this.course3Name);
+      names.push([this.course3Name, this.course3Details, this.course3Highlighted ? '1' : '0']);
+    }
+    if (this.course4Name.length > 0) {
+      names.push([this.course4Name, this.course4Details, this.course4Highlighted ? '1' : '0']);
+    }
+    if (this.course5Name.length > 0) {
+      names.push([this.course5Name, this.course5Details, this.course5Highlighted ? '1' : '0']);
+    }
+    if (this.course6Name.length > 0) {
+      names.push([this.course6Name, this.course6Details, this.course6Highlighted ? '1' : '0']);
     }
     return names;
   }
 
-  private rowDetails(): string[] {
-    const details: string[] = [];
-    if (this.course1Details.length > 0) {
-      details.push(this.course1Details);
-    }
-    if (this.course2Details.length > 0) {
-      details.push(this.course2Details);
-    }
-    if (this.course3Details.length > 0) {
-      details.push(this.course3Details);
-    }
-    return details;
-  }
-
   @Builder
-  courseRow(name: string, details: string) {
+  courseRow(name: string, details: string, highlighted: boolean) {
     Row() {
-      // 金色强调条：对应 Android WidgetCourseAccent（3dp x 30dp）。
+      // 强调条：高亮课程用主色，其余金色（对应 Android/Apple）。
       Column()
         .width(3)
         .height(30)
         .borderRadius(1.5)
-        .backgroundColor($r('app.color.widget_accent'))
+        .backgroundColor(highlighted ? $r('app.color.app_primary_fill') :
+          $r('app.color.widget_accent'))
       Column({ space: 1 }) {
         Text(name)
           .fontSize(14)
@@ -81,6 +90,7 @@ struct TodayCourseCard {
 
   build() {
     Column() {
+      // 标题行
       Row() {
         Text(this.todayTitle)
           .fontSize(16)
@@ -96,6 +106,19 @@ struct TodayCourseCard {
       .height(28)
       .alignItems(VerticalAlign.Center)
 
+      // 日期/状态上下文
+      if (this.dateContext.length > 0) {
+        Text(this.statusText.length > 0 ?
+          this.dateContext + ' · ' + this.statusText : this.dateContext)
+          .fontSize(11)
+          .fontWeight(FontWeight.Medium)
+          .fontColor($r('app.color.widget_text_secondary'))
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .width('100%')
+          .margin({ top: 3 })
+      }
+
       Blank()
         .height(8)
 
@@ -104,18 +127,25 @@ struct TodayCourseCard {
           Text(this.emptyGlyph)
             .fontSize(22)
             .fontColor($r('app.color.widget_primary'))
-          Text(this.emptyText)
-            .fontSize(14)
-            .fontColor($r('app.color.widget_text_secondary'))
+          Column({ space: 2 }) {
+            Text(this.emptyText)
+              .fontSize(14)
+              .fontWeight(FontWeight.Bold)
+              .fontColor($r('app.color.widget_text_primary'))
+            Text(this.statusText)
+              .fontSize(11)
+              .fontColor($r('app.color.widget_text_secondary'))
+          }
+          .alignItems(HorizontalAlign.Start)
         }
         .width('100%')
         .layoutWeight(1)
         .alignItems(VerticalAlign.Center)
       } else {
         Column({ space: 0 }) {
-          ForEach(this.rowNames(), (name: string, index: number) => {
-            this.courseRow(name, this.rowDetails()[index])
-          }, (name: string, index: number) => 'row.' + name + '.' + index.toString())
+          ForEach(this.rows(), (row: string[], index: number) => {
+            this.courseRow(row[0], row[1], row[2] === '1')
+          }, (row: string[], index: number) => 'row.' + row[0] + '.' + index.toString())
           if (this.moreHint.length > 0) {
             Text(this.moreHint)
               .fontSize(11)
@@ -131,10 +161,6 @@ struct TodayCourseCard {
       }
 
       Blank()
-
-      Text(this.tomorrowHint)
-        .fontSize(11)
-        .fontColor($r('app.color.widget_primary'))
     }
     .padding(14)
     .width('100%')

--- a/native/harmony/entry/src/main/ets/widget/pages/TodayCourseCard.ets
+++ b/native/harmony/entry/src/main/ets/widget/pages/TodayCourseCard.ets
@@ -1,15 +1,83 @@
-// 今日课程卡片 UI，对应 iOS 端 TodayCourseWidgetView。
+// 今日课程卡片 UI，对应 iOS 端 TodayCourseWidgetView 与
+// Android 端 widget_today_course.xml：标题行 + 最多 3 行课程
+// （金色强调条 + 课程名/时间·教室）+ 更多提示 + 明日提示 + 空态。
 // 卡片运行环境仅支持受限 ArkTS 子集，这里只使用基础容器与 Text。
 @Entry
 @Component
 struct TodayCourseCard {
   @LocalStorageProp('todayTitle') todayTitle: string = '今日课程';
   @LocalStorageProp('todayCountText') todayCountText: string = '';
-  @LocalStorageProp('todayLines') todayLines: string = '';
+  @LocalStorageProp('course1Name') course1Name: string = '';
+  @LocalStorageProp('course1Details') course1Details: string = '';
+  @LocalStorageProp('course2Name') course2Name: string = '';
+  @LocalStorageProp('course2Details') course2Details: string = '';
+  @LocalStorageProp('course3Name') course3Name: string = '';
+  @LocalStorageProp('course3Details') course3Details: string = '';
   @LocalStorageProp('moreHint') moreHint: string = '';
   @LocalStorageProp('tomorrowHint') tomorrowHint: string = '';
   @LocalStorageProp('emptyGlyph') emptyGlyph: string = '';
   @LocalStorageProp('emptyText') emptyText: string = '';
+
+  private rowNames(): string[] {
+    const names: string[] = [];
+    if (this.course1Name.length > 0) {
+      names.push(this.course1Name);
+    }
+    if (this.course2Name.length > 0) {
+      names.push(this.course2Name);
+    }
+    if (this.course3Name.length > 0) {
+      names.push(this.course3Name);
+    }
+    return names;
+  }
+
+  private rowDetails(): string[] {
+    const details: string[] = [];
+    if (this.course1Details.length > 0) {
+      details.push(this.course1Details);
+    }
+    if (this.course2Details.length > 0) {
+      details.push(this.course2Details);
+    }
+    if (this.course3Details.length > 0) {
+      details.push(this.course3Details);
+    }
+    return details;
+  }
+
+  @Builder
+  courseRow(name: string, details: string) {
+    Row() {
+      // 金色强调条：对应 Android WidgetCourseAccent（3dp x 30dp）。
+      Column()
+        .width(3)
+        .height(30)
+        .borderRadius(1.5)
+        .backgroundColor($r('app.color.widget_accent'))
+      Column({ space: 1 }) {
+        Text(name)
+          .fontSize(14)
+          .fontWeight(FontWeight.Bold)
+          .fontColor($r('app.color.widget_text_primary'))
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .width('100%')
+        Text(details)
+          .fontSize(11)
+          .fontColor($r('app.color.widget_text_secondary'))
+          .maxLines(1)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
+          .width('100%')
+      }
+      .layoutWeight(1)
+      .alignItems(HorizontalAlign.Start)
+      .margin({ left: 8 })
+    }
+    .width('100%')
+    .height(40)
+    .alignItems(VerticalAlign.Center)
+  }
 
   build() {
     Column() {
@@ -17,46 +85,48 @@ struct TodayCourseCard {
         Text(this.todayTitle)
           .fontSize(16)
           .fontWeight(FontWeight.Bold)
-          .fontColor($r('sys.color.ohos_id_color_text_primary'))
+          .fontColor($r('app.color.widget_text_primary'))
         Blank()
         Text(this.todayCountText)
           .fontSize(12)
           .fontWeight(FontWeight.Medium)
-          .fontColor($r('sys.color.ohos_id_color_text_secondary'))
+          .fontColor($r('app.color.widget_text_secondary'))
       }
       .width('100%')
+      .height(28)
+      .alignItems(VerticalAlign.Center)
 
       Blank()
         .height(8)
 
       if (this.emptyText.length > 0) {
-        Column() {
+        Row({ space: 9 }) {
           Text(this.emptyGlyph)
             .fontSize(22)
-            .fontColor($r('sys.color.ohos_id_color_primary'))
+            .fontColor($r('app.color.widget_primary'))
           Text(this.emptyText)
-            .fontSize(13)
-            .fontColor($r('sys.color.ohos_id_color_text_secondary'))
-            .margin({ top: 4 })
+            .fontSize(14)
+            .fontColor($r('app.color.widget_text_secondary'))
         }
         .width('100%')
-        .alignItems(HorizontalAlign.Start)
+        .layoutWeight(1)
+        .alignItems(VerticalAlign.Center)
       } else {
-        Column() {
-          Text(this.todayLines)
-            .fontSize(12)
-            .fontColor($r('sys.color.ohos_id_color_text_primary'))
-            .maxLines(3)
-            .textOverflow({ overflow: TextOverflow.Ellipsis })
-            .width('100%')
+        Column({ space: 0 }) {
+          ForEach(this.rowNames(), (name: string, index: number) => {
+            this.courseRow(name, this.rowDetails()[index])
+          }, (name: string, index: number) => 'row.' + name + '.' + index.toString())
           if (this.moreHint.length > 0) {
             Text(this.moreHint)
-              .fontSize(10)
-              .fontColor($r('sys.color.ohos_id_color_text_secondary'))
-              .margin({ top: 4 })
+              .fontSize(11)
+              .fontColor($r('app.color.widget_text_secondary'))
+              .maxLines(1)
+              .width('100%')
+              .margin({ top: 2 })
           }
         }
         .width('100%')
+        .layoutWeight(1)
         .alignItems(HorizontalAlign.Start)
       }
 
@@ -64,12 +134,13 @@ struct TodayCourseCard {
 
       Text(this.tomorrowHint)
         .fontSize(11)
-        .fontColor($r('sys.color.ohos_id_color_primary'))
+        .fontColor($r('app.color.widget_primary'))
     }
     .padding(14)
     .width('100%')
     .height('100%')
     .alignItems(HorizontalAlign.Start)
-    .backgroundColor($r('sys.color.ohos_id_color_sub_background'))
+    .borderRadius(16)
+    .backgroundColor($r('app.color.widget_background'))
   }
 }

--- a/native/harmony/entry/src/main/resources/base/element/color.json
+++ b/native/harmony/entry/src/main/resources/base/element/color.json
@@ -61,6 +61,18 @@
       "value": "#FFFFFF"
     },
     {
+      "name": "app_now_indicator",
+      "value": "#FF3B30"
+    },
+    {
+      "name": "app_holiday",
+      "value": "#C62835"
+    },
+    {
+      "name": "app_primary_dark",
+      "value": "#0C4A42"
+    },
+    {
       "name": "widget_primary",
       "value": "#176B5D"
     },

--- a/native/harmony/entry/src/main/resources/base/element/color.json
+++ b/native/harmony/entry/src/main/resources/base/element/color.json
@@ -59,6 +59,26 @@
     {
       "name": "app_segmented_selection",
       "value": "#FFFFFF"
+    },
+    {
+      "name": "widget_primary",
+      "value": "#176B5D"
+    },
+    {
+      "name": "widget_accent",
+      "value": "#E6B048"
+    },
+    {
+      "name": "widget_background",
+      "value": "#F4F7F4"
+    },
+    {
+      "name": "widget_text_primary",
+      "value": "#15201D"
+    },
+    {
+      "name": "widget_text_secondary",
+      "value": "#687670"
     }
   ]
 }

--- a/native/harmony/entry/src/main/resources/dark/element/color.json
+++ b/native/harmony/entry/src/main/resources/dark/element/color.json
@@ -59,6 +59,26 @@
     {
       "name": "app_segmented_selection",
       "value": "#636366"
+    },
+    {
+      "name": "widget_primary",
+      "value": "#5AD2B8"
+    },
+    {
+      "name": "widget_accent",
+      "value": "#E6B048"
+    },
+    {
+      "name": "widget_background",
+      "value": "#181E1B"
+    },
+    {
+      "name": "widget_text_primary",
+      "value": "#F2F6F4"
+    },
+    {
+      "name": "widget_text_secondary",
+      "value": "#A8B2AD"
     }
   ]
 }

--- a/native/harmony/entry/src/main/resources/dark/element/color.json
+++ b/native/harmony/entry/src/main/resources/dark/element/color.json
@@ -61,6 +61,18 @@
       "value": "#636366"
     },
     {
+      "name": "app_now_indicator",
+      "value": "#FF453A"
+    },
+    {
+      "name": "app_holiday",
+      "value": "#FF9A9D"
+    },
+    {
+      "name": "app_primary_dark",
+      "value": "#0C4A42"
+    },
+    {
       "name": "widget_primary",
       "value": "#5AD2B8"
     },

--- a/native/harmony/entry/src/test/List.test.ets
+++ b/native/harmony/entry/src/test/List.test.ets
@@ -10,6 +10,7 @@ import dailyCoursePlanningTest from './DailyCoursePlanning.test';
 import adaptivePolicyTest from './AdaptivePolicy.test';
 import robustnessTest from './Robustness.test';
 import credentialStoreTest from './CredentialStore.test';
+import todayCourseWidgetDataTest from './TodayCourseWidgetData.test';
 
 export default function testsuite() {
   strictDatesTest();
@@ -23,4 +24,5 @@ export default function testsuite() {
   adaptivePolicyTest();
   robustnessTest();
   credentialStoreTest();
+  todayCourseWidgetDataTest();
 }

--- a/native/harmony/entry/src/test/TodayCourseWidgetData.test.ets
+++ b/native/harmony/entry/src/test/TodayCourseWidgetData.test.ets
@@ -1,0 +1,85 @@
+// 今日课程卡片数据层测试：课程过滤（周/星期）+ 绑定数据（行/空态/提示）。
+// 与 Android TodayCourseWidgetLogicTest 的语义对齐。
+import { describe, it, expect } from '@ohos/hypium';
+import { DateParts } from '../main/ets/common/StrictDates';
+import {
+  TodayCourseWidgetData, WidgetArchive, WidgetArchiveCourse
+} from '../main/ets/widget/TodayCourseWidgetData';
+
+function course(id: string, name: string, room: string, timeRange: string,
+  weekday: number, weeks: number[], startSlot: number): WidgetArchiveCourse {
+  return new WidgetArchiveCourse(id, name, room, timeRange, weekday, weeks, [], startSlot);
+}
+
+function archive(): WidgetArchive {
+  const courses: WidgetArchiveCourse[] = [
+    course('c1', '高等数学', '教一-101', '08:00-09:35', 1, [1, 2, 3], 0),
+    course('c2', '大学英语', '教二-202', '10:10-11:45', 1, [1, 2, 3], 2),
+    course('c3', '物理实验', '实验楼-301', '14:00-15:40', 2, [1, 2, 3], 5),
+    course('c4', '数据结构', '教三-303', '16:00-17:35', 1, [2], 7),
+  ];
+  return new WidgetArchive('2026-03-02', '2026-03-02T00:00:00Z', courses);
+}
+
+export default function todayCourseWidgetDataTest() {
+  describe('TodayCourseWidgetDataTest', () => {
+    it('courses_on_filters_by_weekday_and_week', 0, () => {
+      // 2026-03-02 是周一（第一周）。
+      const mondayWeek1: DateParts = new DateParts(2026, 3, 2);
+      const result: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(mondayWeek1, archive());
+      expect(result.length).assertEqual(2); // c1 与 c2 在周一、包含第 1 周
+      expect(result[0].name).assertEqual('高等数学');
+      expect(result[1].name).assertEqual('大学英语');
+      // 第 2 周周一：c1/c2/c4（c4 只在第 2 周）。
+      const mondayWeek2: DateParts = new DateParts(2026, 3, 9);
+      const week2: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(mondayWeek2, archive());
+      expect(week2.length).assertEqual(3);
+      expect(week2[2].name).assertEqual('数据结构');
+    });
+
+    it('courses_on_sorts_by_start_slot_then_name', 0, () => {
+      const result: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(
+        new DateParts(2026, 3, 2), archive());
+      expect(result[0].startSlot).assertEqual(0);
+      expect(result[1].startSlot).assertEqual(2);
+    });
+
+    it('binding_produces_structured_course_rows', 0, () => {
+      const today: DateParts = new DateParts(2026, 3, 2);
+      const data: Record<string, Object> = TodayCourseWidgetData.binding(archive(), 3, today);
+      expect(data['todayTitle']).assertEqual('今日课程');
+      expect(data['todayCountText']).assertEqual('2 门');
+      expect(data['course1Name']).assertEqual('高等数学');
+      expect(data['course1Details']).assertEqual('08:00-09:35 · 教一-101');
+      expect(data['course2Name']).assertEqual('大学英语');
+      expect(data['course3Name']).assertEqual('');
+      expect(data['moreHint']).assertEqual('');
+      expect(data['emptyText']).assertEqual('');
+      expect(data['tomorrowHint']).assertEqual('明天 1 门课');
+    });
+
+    it('binding_respects_course_limit_for_small_dimension', 0, () => {
+      const today: DateParts = new DateParts(2026, 3, 9); // 第 2 周周一：3 门课
+      const data: Record<string, Object> = TodayCourseWidgetData.binding(archive(), 2, today);
+      expect(data['course2Name']).assertEqual('大学英语');
+      expect(data['course3Name']).assertEqual('');
+      expect(data['moreHint']).assertEqual('另有 1 门课程');
+    });
+
+    it('binding_empty_state_without_archive', 0, () => {
+      const data: Record<string, Object> = TodayCourseWidgetData.binding(null, 3,
+        new DateParts(2026, 3, 2));
+      expect(data['emptyGlyph']).assertEqual('↻');
+      expect(data['emptyText']).assertEqual('打开应用获取个人课表');
+      expect(data['course1Name']).assertEqual('');
+      expect(data['todayCountText']).assertEqual('');
+    });
+
+    it('binding_empty_state_on_course_free_day', 0, () => {
+      const data: Record<string, Object> = TodayCourseWidgetData.binding(archive(), 3,
+        new DateParts(2026, 3, 4)); // 周三无课
+      expect(data['emptyGlyph']).assertEqual('✓');
+      expect(data['emptyText']).assertEqual('今天没有课程');
+    });
+  });
+}

--- a/native/harmony/entry/src/test/TodayCourseWidgetData.test.ets
+++ b/native/harmony/entry/src/test/TodayCourseWidgetData.test.ets
@@ -1,20 +1,23 @@
-// 今日课程卡片数据层测试：课程过滤（周/星期）+ 绑定数据（行/空态/提示）。
-// 与 Android TodayCourseWidgetLogicTest 的语义对齐。
+// 今日课程卡片数据层测试：课程过滤 + 阶段/高亮/上下文 + 绑定数据（行/空态）。
+// 与 Android TodayCourseWidgetLogicTest / Apple TodayCourseWidgetDataTests 对齐。
 import { describe, it, expect } from '@ohos/hypium';
 import { DateParts } from '../main/ets/common/StrictDates';
 import {
-  TodayCourseWidgetData, WidgetArchive, WidgetArchiveCourse
+  TodayCourseWidgetData, WidgetArchive, WidgetArchiveCourse,
+  WidgetCoursePreferences, CoursePhase
 } from '../main/ets/widget/TodayCourseWidgetData';
 
 function course(id: string, name: string, room: string, timeRange: string,
-  weekday: number, weeks: number[], startSlot: number): WidgetArchiveCourse {
-  return new WidgetArchiveCourse(id, name, room, timeRange, weekday, weeks, [], startSlot);
+  weekday: number, weeks: number[], startSlot: number,
+  sectionText: string = '1-2节'): WidgetArchiveCourse {
+  return new WidgetArchiveCourse(id, name, '测试教师', room, sectionText, timeRange,
+    weekday, weeks, [], startSlot);
 }
 
 function archive(): WidgetArchive {
   const courses: WidgetArchiveCourse[] = [
     course('c1', '高等数学', '教一-101', '08:00-09:35', 1, [1, 2, 3], 0),
-    course('c2', '大学英语', '教二-202', '10:10-11:45', 1, [1, 2, 3], 2),
+    course('c2', '大学英语', '教二-202', '10:10-11:45', 1, [1, 2, 3], 2, '3-4节'),
     course('c3', '物理实验', '实验楼-301', '14:00-15:40', 2, [1, 2, 3], 5),
     course('c4', '数据结构', '教三-303', '16:00-17:35', 1, [2], 7),
   ];
@@ -27,59 +30,73 @@ export default function todayCourseWidgetDataTest() {
       // 2026-03-02 是周一（第一周）。
       const mondayWeek1: DateParts = new DateParts(2026, 3, 2);
       const result: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(mondayWeek1, archive());
-      expect(result.length).assertEqual(2); // c1 与 c2 在周一、包含第 1 周
+      expect(result.length).assertEqual(2);
       expect(result[0].name).assertEqual('高等数学');
       expect(result[1].name).assertEqual('大学英语');
-      // 第 2 周周一：c1/c2/c4（c4 只在第 2 周）。
       const mondayWeek2: DateParts = new DateParts(2026, 3, 9);
       const week2: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(mondayWeek2, archive());
       expect(week2.length).assertEqual(3);
       expect(week2[2].name).assertEqual('数据结构');
     });
 
-    it('courses_on_sorts_by_start_slot_then_name', 0, () => {
-      const result: WidgetArchiveCourse[] = TodayCourseWidgetData.coursesOn(
-        new DateParts(2026, 3, 2), archive());
-      expect(result[0].startSlot).assertEqual(0);
-      expect(result[1].startSlot).assertEqual(2);
+    it('course_phase_detects_upcoming_in_progress_finished', 0, () => {
+      const c: WidgetArchiveCourse = course('c', '高数', '教一-101', '08:00-09:35', 1, [1], 0);
+      expect(TodayCourseWidgetData.coursePhase(c, new DateParts(2026, 3, 2), 7 * 60))
+        .assertEqual(CoursePhase.upcoming);
+      expect(TodayCourseWidgetData.coursePhase(c, new DateParts(2026, 3, 2), 8 * 60 + 30))
+        .assertEqual(CoursePhase.inProgress);
+      expect(TodayCourseWidgetData.coursePhase(c, new DateParts(2026, 3, 2), 10 * 60))
+        .assertEqual(CoursePhase.finished);
     });
 
-    it('binding_produces_structured_course_rows', 0, () => {
+    it('binding_produces_context_status_and_highlighted_rows', 0, () => {
       const today: DateParts = new DateParts(2026, 3, 2);
-      const data: Record<string, Object> = TodayCourseWidgetData.binding(archive(), 3, today);
+      const data: Record<string, Object> = TodayCourseWidgetData.binding(
+        archive(), new WidgetCoursePreferences(), today, 8 * 60 + 30);
       expect(data['todayTitle']).assertEqual('今日课程');
       expect(data['todayCountText']).assertEqual('2 门');
-      expect(data['course1Name']).assertEqual('高等数学');
-      expect(data['course1Details']).assertEqual('08:00-09:35 · 教一-101');
-      expect(data['course2Name']).assertEqual('大学英语');
-      expect(data['course3Name']).assertEqual('');
-      expect(data['moreHint']).assertEqual('');
-      expect(data['emptyText']).assertEqual('');
-      expect(data['tomorrowHint']).assertEqual('明天 1 门课');
+      expect(String(data['dateContext'])).assertEqual('3月2日 · 周一 · 第1周');
+      expect(String(data['statusText'])).assertEqual('进行中 · 09:35 下课');
+      // 高等数学（08:00-09:35）正在进行中 -> 高亮 + 前缀
+      expect(String(data['course1Name'])).assertEqual('进行中 · 高等数学');
+      expect(data['course1Highlighted']).assertEqual(true);
+      // 大学英语（10:10）下一节 -> 前缀
+      expect(String(data['course2Name'])).assertEqual('下一节 · 大学英语');
+      expect(String(data['course2Details'])).assertEqual('10:10-11:45 · 3-4节 · 教二-202 · 测试教师');
+      expect(String(data['course3Name'])).assertEqual('');
     });
 
-    it('binding_respects_course_limit_for_small_dimension', 0, () => {
+    it('binding_respects_course_limit_and_shows_more_hint', 0, () => {
       const today: DateParts = new DateParts(2026, 3, 9); // 第 2 周周一：3 门课
-      const data: Record<string, Object> = TodayCourseWidgetData.binding(archive(), 2, today);
-      expect(data['course2Name']).assertEqual('大学英语');
-      expect(data['course3Name']).assertEqual('');
-      expect(data['moreHint']).assertEqual('另有 1 门课程');
+      const data: Record<string, Object> = TodayCourseWidgetData.binding(
+        archive(), new WidgetCoursePreferences(true, true, 2), today, 9 * 60);
+      // 9:00 时大学英语（10:10）为下一节 -> 前缀
+      expect(String(data['course2Name'])).assertEqual('下一节 · 大学英语');
+      expect(String(data['course3Name'])).assertEqual('');
+      expect(String(data['moreHint'])).assertEqual('另有 1 门课程');
     });
 
     it('binding_empty_state_without_archive', 0, () => {
-      const data: Record<string, Object> = TodayCourseWidgetData.binding(null, 3,
-        new DateParts(2026, 3, 2));
-      expect(data['emptyGlyph']).assertEqual('↻');
-      expect(data['emptyText']).assertEqual('打开应用获取个人课表');
-      expect(data['course1Name']).assertEqual('');
-      expect(data['todayCountText']).assertEqual('');
+      const data: Record<string, Object> = TodayCourseWidgetData.binding(
+        null, new WidgetCoursePreferences(), new DateParts(2026, 3, 2), 9 * 60);
+      expect(String(data['emptyGlyph'])).assertEqual('↻');
+      expect(String(data['emptyText'])).assertEqual('打开应用获取个人课表');
+      expect(String(data['course1Name'])).assertEqual('');
+      expect(String(data['todayCountText'])).assertEqual('');
     });
 
     it('binding_empty_state_on_course_free_day', 0, () => {
-      const data: Record<string, Object> = TodayCourseWidgetData.binding(archive(), 3,
-        new DateParts(2026, 3, 4)); // 周三无课
-      expect(data['emptyGlyph']).assertEqual('✓');
-      expect(data['emptyText']).assertEqual('今天没有课程');
+      const data: Record<string, Object> = TodayCourseWidgetData.binding(
+        archive(), new WidgetCoursePreferences(), new DateParts(2026, 3, 4), 9 * 60);
+      expect(String(data['emptyGlyph'])).assertEqual('✓');
+      expect(String(data['emptyText'])).assertEqual('今日无课');
+      expect(String(data['statusText'])).assertEqual('今天可以自由安排');
+    });
+
+    it('preview_archive_contains_sample_courses', 0, () => {
+      const preview: WidgetArchive = TodayCourseWidgetData.previewArchive();
+      expect(preview.courses.length).assertEqual(6);
+      expect(preview.courses[0].name).assertEqual('高等数学');
     });
   });
 }


### PR DESCRIPTION
## Summary
- enrich the HarmonyOS today-course widget and settings controls
- align tablet and PC planner/calendar layouts with their native counterparts
- improve semester settings and credential-store failure reporting

## Validation
- ./scripts/native-harmony-build.sh (69 tests passed)
- npm test
- git diff --check